### PR TITLE
Add preliminary support for GDEW075T7 (new 7.5" screen)

### DIFF
--- a/papertty.py
+++ b/papertty.py
@@ -312,7 +312,7 @@ def get_drivers():
     driverdict = {}
     driverlist = [drivers_partial.EPD1in54, drivers_partial.EPD2in13, drivers_partial.EPD2in13v2, drivers_partial.EPD2in9,
                   drivers_partial.EPD2in13d,
-                  drivers_full.EPD2in7, drivers_full.EPD4in2, drivers_full.EPD7in5,
+                  drivers_full.EPD2in7, drivers_full.EPD4in2, drivers_full.EPD7in5, drivers_full.EPD7in5v2,
                   drivers_color.EPD4in2b, drivers_color.EPD7in5b, drivers_color.EPD5in83, drivers_color.EPD5in83b,
                   drivers_colordraw.EPD1in54b, drivers_colordraw.EPD1in54c, drivers_colordraw.EPD2in13b,
                   drivers_colordraw.EPD2in7b, drivers_colordraw.EPD2in9b,


### PR DESCRIPTION
Partial refresh is not supported yet, so this can only be used with full refresh for now.

I'm working on partial refresh, but am having a problem with "partial window" (where only a part of the screen is refreshed at a time). At the moment, I've got to the point in local dev where I "fake" full refresh support but actually do a partial refresh even when `--nopartial` is enabled; this faking is so that PaperTTY provides a full screen to refresh rather than just the part that needs to be updated.

All that partial stuff is still in the debugging phase so I haven't uploaded it yet, but till then, I thought I might as well upload the full-refresh part for people to use :slightly_smiling_face: