### PR TITLE
exit on SIGINT even if noclear was set

### DIFF
--- a/papertty.py
+++ b/papertty.py
@@ -441,7 +441,7 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, sleep, ttyrows, 
         print("Exiting (SIGINT)...")
         if not noclear:
             ptty.showtext(oldbuff, fill=ptty.white, **textargs)
-            sys.exit(0)
+        sys.exit(0)
 
     # toggle scrub flag when SIGUSR1 received
     def sigusr1_handler(sig, frame):


### PR DESCRIPTION
PaperTTY would not terminate upon receiving SIGINT or Ctrl-C was input if --noclear was given on command line. This should fix it.