### PR TITLE
Improved IT8951 performance for 8-bit/color graphics (i.e. VNC) (#32)

### DIFF
--- a/drivers/driver_it8951.py
+++ b/drivers/driver_it8951.py
@@ -291,7 +291,7 @@ class IT8951(DisplayDriver):
             # The driver board assumes all data is read in as 16bit ints. To match
             # the endianness every pair of bytes must be swapped.
             # The image is always padded to a multiple of 8, so we can safely go in steps of 4.
-            for i in range(0, length(frame_buffer), 4):
+            for i in range(0, len(frame_buffer), 4):
                 if frame_buffer[i + 2] and frame_buffer[i + 3]:
                     packed_buffer += [0xFF]
                 elif frame_buffer[i + 2]:
@@ -309,7 +309,6 @@ class IT8951(DisplayDriver):
         else:
             # old packing code for grayscale (VNC)
             image_grey = image.convert("L")
-            pixels = image_grey.load()
             frame_buffer = list(image_grey.getdata())
 
             # For now, only 4 bit packing is supported. Theoretically we could

--- a/drivers/driver_it8951.py
+++ b/drivers/driver_it8951.py
@@ -283,54 +283,47 @@ class IT8951(DisplayDriver):
             # B/W pictured can be processed more quickly
             frame_buffer = list(image.getdata())
 
-            packed_buffer = [0] * ((len(frame_buffer) + 1) // 2)
             # For now, only 4 bit packing is supported. Theoretically we could
             # achieve a transfer speed up by using 2 bit packing for black and white
             # images. However, 2bpp doesn't seem to play well with the DU rendering
             # mode.
+            packed_buffer = []
             # The driver board assumes all data is read in as 16bit ints. To match
             # the endianness every pair of bytes must be swapped.
-            for i in range(0, len(frame_buffer), 4):
-                if frame_buffer[i] and frame_buffer[i + 1]:
-                    packed_buffer[i // 2 + 1] = 0xFF
-                elif frame_buffer[i]:
-                    packed_buffer[i // 2 + 1] = 0x0F
-                elif frame_buffer[i + 1]:
-                    packed_buffer[i // 2 + 1] = 0xF0
-
+            # The image is always padded to a multiple of 8, so we can safely go in steps of 4.
+            for i in range(0, length(frame_buffer), 4):
                 if frame_buffer[i + 2] and frame_buffer[i + 3]:
-                    packed_buffer[i // 2] = 0xFF
+                    packed_buffer += [0xFF]
                 elif frame_buffer[i + 2]:
-                    packed_buffer[i // 2] = 0x0F
+                    packed_buffer += [0x0F]
                 elif frame_buffer[i + 3]:
-                    packed_buffer[i // 2] = 0xF0
+                    packed_buffer += [0xF0]
+
+                if frame_buffer[i] and frame_buffer[i + 1]:
+                    packed_buffer += [0xFF]
+                elif frame_buffer[i]:
+                    packed_buffer += [0x0F]
+                elif frame_buffer[i + 1]:
+                    packed_buffer += [0xF0]
             return packed_buffer
         else:
             # old packing code for grayscale (VNC)
             image_grey = image.convert("L")
             pixels = image_grey.load()
-            frame_buffer = [
-                pixels[x, y]
-                for y in range(image.height)
-                for x in range(image.width)
-            ]
+            frame_buffer = list(image_grey.getdata())
 
             # For now, only 4 bit packing is supported. Theoretically we could
             # achieve a transfer speed up by using 2 bit packing for black and white
             # images. However, 2bpp doesn't seem to play well with the DU rendering
             # mode.
             packed_buffer = []
-            for i in range(0, len(frame_buffer), 2):
-                value = (frame_buffer[i] >> 4) & 0x0F
-                if i + 1 < len(frame_buffer):
-                    value |= frame_buffer[i + 1] & 0xF0
-                packed_buffer += [value]
 
             # The driver board assumes all data is read in as 16bit ints. To match
             # the endianness every pair of bytes must be swapped.
-            # TODO: This should be included in the previous step as in the B/W case
-            for i in range(0, len(packed_buffer), 2):
-                packed_buffer[i], packed_buffer[i + 1] = (
-                        packed_buffer[i + 1], packed_buffer[i])
+            # The image is always padded to a multiple of 8, so we can safely go in steps of 4.
+            for i in range(0, len(frame_buffer), 4):
+                # Values are in the range 0..255, so we don't need to "and" after we shift
+                packed_buffer += [(frame_buffer[i + 2] >> 4) | (frame_buffer[i + 3] & 0xF0)]
+                packed_buffer += [(frame_buffer[i] >> 4) | (frame_buffer[i + 1] & 0xF0)]
 
             return packed_buffer


### PR DESCRIPTION
Tested with TTY using 'L' (8-bit) instead '1' (B/W) mode.