### PR TITLE
Font height determination fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- **2020-01-25**
+  - Added support for more cursors.
+- **2020-01-22**
+  - Added Unicode support for systems providing /dev/vcsu
 - **2019-12-07**
   - Added basic support for EPD7in5v2 (GDEW075T7)
 - **2019-11-03**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # PaperTTY
 
+## Cursor Update *(2020-01-25)*
+
+The `terminal` mode now supports different cursors. `--nocursor` had been deprecated in favor of `--cursor=none`. The usual underscore-like cursor is set via `--cursor=default`, which, as the name suggests, is also the default mode. There is also a `--cursor=block` option, which inverts the colors at the cursor's location. Finally, there is also an option to provide a numerical value, e.g. `--cursor=5`, which draws an underscore cursor shifted 5 pixels towards the top; `--cursor=default` and `--cursor=0` are thus equivalent.
+
 ## Unicode Update *(2020-01-22)*
 
 On systems with /dev/vcsu* (e.g. Raspbian Stretch or Buster, with kernel 4.19+) and when using a TrueType font, the `terminal` mode now has full support for Unicode output. This is automatic, with a fallback to 8-bit if either of these requirements isn't met. We've also changed the standard encoding for 8-bit to ISO-8859-1, which should be a little closer to what the `vcs` device provides.

--- a/papertty.py
+++ b/papertty.py
@@ -220,7 +220,7 @@ class PaperTTY:
         cur_x, cur_y = cursor[0], cursor[1]
         # get the width of the character under cursor
         # (in case we didn't use a fixed width font...)
-        width = self.font.getsize(cursor[2])[0]
+        width = self.font_width
         # desired cursor width
         cur_width = width - 1
         # get font height

--- a/papertty.py
+++ b/papertty.py
@@ -239,7 +239,7 @@ class PaperTTY:
         cur_x, cur_y = cursor[0], cursor[1]
         # get the width of the character under cursor
         # (in case we didn't use a fixed width font...)
-        width = self.font.getsize(cursor[2])[0]
+        width = self.font_width
         # get font height
         height = self.font_height
         upper_left = (cur_x * width, cur_y * height)

--- a/papertty.py
+++ b/papertty.py
@@ -218,8 +218,6 @@ class PaperTTY:
 
     def draw_line_cursor(self, cursor, draw):
         cur_x, cur_y = cursor[0], cursor[1]
-        # get the width of the character under cursor
-        # (in case we didn't use a fixed width font...)
         width = self.font_width
         # desired cursor width
         cur_width = width - 1
@@ -237,8 +235,6 @@ class PaperTTY:
 
     def draw_block_cursor(self, cursor, image):
         cur_x, cur_y = cursor[0], cursor[1]
-        # get the width of the character under cursor
-        # (in case we didn't use a fixed width font...)
         width = self.font_width
         # get font height
         height = self.font_height

--- a/papertty.py
+++ b/papertty.py
@@ -465,10 +465,9 @@ def vnc(settings, host, display, password, rotate, invert, sleep, fullevery):
 @click.option('--scrub', 'apply_scrub', is_flag=True, default=False, help='Apply scrub when starting up',
               show_default=True)
 @click.option('--autofit', is_flag=True, default=False, help='Autofit terminal size to font size', show_default=True)
-@click.option('--attributes', is_flag=True, default=False, help='Use attributes', show_default=True)
 @click.pass_obj
 def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, ttyrows, ttycols, portrait, flipx, flipy,
-             spacing, apply_scrub, autofit, attributes):
+             spacing, apply_scrub, autofit):
     """Display virtual console on an e-Paper display, exit with Ctrl-C."""
     settings.args['font'] = font
     settings.args['fontsize'] = fontsize

--- a/papertty.py
+++ b/papertty.py
@@ -64,14 +64,16 @@ class PaperTTY:
         self.driver = get_drivers()[driver]['class']()
         self.font = self.load_font(font, fontsize) if font else None
         if self.font:
-            # get physical dimensions of font
-            self.font_width = self.font.getsize('M')[0]
+            # get physical dimensions of font. Take the average width of
+            # 1000 M's because oblique fonts a complicated.
+            self.font_width = self.font.getsize('M' * 1000)[0] // 1000
             if 'getmetrics' in dir(self.font):
                 metrics_ascent, metrics_descent = self.font.getmetrics()
                 self.spacing = int(spacing) if spacing != 'auto' else (metrics_descent - 2)
                 print('Setting spacing to {}.'.format(self.spacing))
                 # despite what the PIL docs say, ascent appears to be the
-                # height of the font, while descent is not, in fact, negative
+                # height of the font, while descent is not, in fact, negative.
+                # Couuld use testing with more fonts.
                 self.font_height = metrics_ascent + self.spacing
             else:
                 # No autospacing for pil fonts, but they usually don't need it.


### PR DESCRIPTION
I've noticed a while ago that the cursor doesn't line up with the rest of the text when using TrueType fonts and autofit would overestimate the number of rows. Some experimenting led me to the realization that [PIL's documentation](https://pillow.readthedocs.io/en/stable/reference/ImageFont.html#PIL.ImageFont.FreeTypeFont.getmetrics) is not seeing eye-to-eye with reality. It appears that the ascent metric is in fact the font height. At least it worked well for me.

Tested with Andale Mono, Inconsolata, Consolas and ProFontWindows, all of which displayed at sensible row counts and with proper cursor positioning, though all except Andale could benefit from some spacing. Terminus at 22 pixels and the default font worked as expected.