### PR TITLE
Interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- **2020-01-29**
+  - Added interactive mode.
 - **2020-01-25**
   - Added support for more cursors.
 - **2020-01-22**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- **2020-02-15**
+- **2020-02-18**
   - Added interactive mode.
 - **2020-01-25**
   - Added support for more cursors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- **2020-01-29**
+- **2020-02-15**
   - Added interactive mode.
 - **2020-01-25**
   - Added support for more cursors.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PaperTTY
 
-## Interactive Update *(2020-02-15)*
+## Interactive Update *(2020-02-18)*
 
 Starting `terminal` with the `--interactive` option adds a menu to the Ctrl-C handler that allows you to change the font, font size and spacing on the fly. This should be helpful when trying out fonts.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PaperTTY
 
-## Interactive Update *(2020-01-29)*
+## Interactive Update *(2020-02-15)*
 
 Starting `terminal` with the `--interactive` option adds a menu to the Ctrl-C handler that allows you to change the font, font size and spacing on the fly. This should be helpful when trying out fonts.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # PaperTTY
 
+## Interactive Update *(2020-01-29)*
+
+Starting `terminal` with the `--interactive` option adds a menu to the Ctrl-C handler that allows you to change the font, font size and spacing on the fly. This should be helpful when trying out fonts.
+
 ## Cursor Update *(2020-01-25)*
 
 The `terminal` mode now supports different cursors. `--nocursor` had been deprecated in favor of `--cursor=none`. The usual underscore-like cursor is set via `--cursor=default`, which, as the name suggests, is also the default mode. There is also a `--cursor=block` option, which inverts the colors at the cursor's location. Finally, there is also an option to provide a numerical value, e.g. `--cursor=5`, which draws an underscore cursor shifted 5 pixels towards the top; `--cursor=default` and `--cursor=0` are thus equivalent.

--- a/drivers/driver_it8951.py
+++ b/drivers/driver_it8951.py
@@ -277,6 +277,10 @@ class IT8951(DisplayDriver):
         # Blit the image to the display
         self.display_area(x, y, width, height, update_mode)
 
+    def clear(self):
+        image = Image.new('1', (self.width, self.height), self.white)
+        self.draw(0, 0, image, self.DISPLAY_UPDATE_MODE_INIT)
+
     def pack_image(self, image):
         """Packs a PIL image for transfer over SPI to the driver board."""
         if image.mode == '1':

--- a/drivers/drivers_base.py
+++ b/drivers/drivers_base.py
@@ -66,6 +66,12 @@ class DisplayDriver(ABC):
         for x in range(0, self.width, fillsize):
             self.draw(x, 0, image)
 
+    def clear(self):
+        """Clears the display"""
+        image = Image.new('1', (self.height, self.width), self.black)
+        self.draw(0, 0, image)
+        image = Image.new('1', (self.height, self.width), self.white)
+        self.draw(0, 0, image)
 
 class SpecialDriver(DisplayDriver):
     """Drivers that don't control hardware"""

--- a/papertty.py
+++ b/papertty.py
@@ -559,7 +559,7 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                 ptty.showtext(oldbuff, fill=ptty.white, **textargs)
             sys.exit(0)
         elif ch == 'f':
-            print('Current font: {}'.format(ptty.font))
+            print('Current font: {}'.format(ptty.fontfile))
             print('Enter new font (leave empty to abort):')
             font_name = sys.stdin.readline().strip()
             if font_name:

--- a/papertty.py
+++ b/papertty.py
@@ -527,15 +527,17 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                 ptty.showtext(oldbuff, fill=ptty.white, **textargs)
             sys.exit(0)
         if ch == 'f':
-            print('Enter new font:')
+            print('Current font: {}'.format(ptty.font))
+            print('Enter new font (leave empty to abort):')
             font_name = sys.stdin.readline().strip()
-            ptty.spacing = spacing
-            ptty.font = ptty.load_font(font_name)
-            if autofit:
-                max_dim = ptty.fit(portrait)
-                print("Automatic resize of TTY to {} rows, {} columns".format(max_dim[1], max_dim[0]))
-                ptty.set_tty_size(ptty.ttydev(vcsa), max_dim[1], max_dim[0])
-            flags['force_redraw'] = True
+            if font_name:
+                ptty.spacing = spacing
+                ptty.font = ptty.load_font(font_name)
+                if autofit:
+                    max_dim = ptty.fit(portrait)
+                    print("Automatic resize of TTY to {} rows, {} columns".format(max_dim[1], max_dim[0]))
+                    ptty.set_tty_size(ptty.ttydev(vcsa), max_dim[1], max_dim[0])
+                flags['force_redraw'] = True
 
     # toggle scrub flag when SIGUSR1 received
     def sigusr1_handler(sig, frame):

--- a/papertty.py
+++ b/papertty.py
@@ -552,6 +552,7 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
             print('    (h) to change font size,')
         print('    (x) to exit,')
         print('    anything else to continue.')
+        print('Use --font {} --size {} --spacing {} for the current setting.'.format(ptty.fontfile, ptty.fontsize, ptty.spacing))
 
         ch = sys.stdin.readline().strip()
         if ch == 'x':

--- a/papertty.py
+++ b/papertty.py
@@ -218,8 +218,6 @@ class PaperTTY:
 
     def draw_line_cursor(self, cursor, draw):
         cur_x, cur_y = cursor[0], cursor[1]
-        # get the width of the character under cursor
-        # (in case we didn't use a fixed width font...)
         width = self.font_width
         # desired cursor width
         cur_width = width - 1
@@ -237,8 +235,6 @@ class PaperTTY:
 
     def draw_block_cursor(self, cursor, image):
         cur_x, cur_y = cursor[0], cursor[1]
-        # get the width of the character under cursor
-        # (in case we didn't use a fixed width font...)
         width = self.font_width
         # get font height
         height = self.font_height

--- a/papertty.py
+++ b/papertty.py
@@ -602,8 +602,7 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                     sys.exit(0)
                 elif ch == 'f':
                     print('Current font: {}'.format(ptty.fontfile))
-                    print('Enter new font (leave empty to abort):')
-                    font_name = sys.stdin.readline().strip()
+                    font_name = click.prompt('Enter new font (leave empty to abort)')
                     if font_name:
                         ptty.spacing = spacing
                         ptty.font = ptty.load_font(font_name, keep_if_not_found=True)
@@ -612,12 +611,13 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                             print("Automatic resize of TTY to {} rows, {} columns".format(max_dim[1], max_dim[0]))
                             ptty.set_tty_size(ptty.ttydev(vcsa), max_dim[1], max_dim[0])
                         oldbuff = None
+                    else:
+                        print('Font not changed')
                 elif ch == 's':
                     print('Current spacing: {}'.format(ptty.spacing))
-                    print('Enter new spacing (leave empty to abort):')
                     new_spacing = None
                     try:
-                        new_spacing = int(sys.stdin.readline().strip())
+                        new_spacing = int(click.prompt('Enter new spacing (leave empty to abort)'))
                     except:
                         pass
                     if new_spacing or new_spacing == 0:
@@ -628,12 +628,13 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                             print("Automatic resize of TTY to {} rows, {} columns".format(max_dim[1], max_dim[0]))
                             ptty.set_tty_size(ptty.ttydev(vcsa), max_dim[1], max_dim[0])
                         oldbuff = None
+                    else:
+                        print('Spacing not changed')
                 elif ch == 'h' and ptty.is_truetype:
                     print('Current font size: {}'.format(ptty.fontsize))
-                    print('Enter new font size (leave empty to abort):')
                     new_fontsize = None
                     try:
-                        new_fontsize = int(sys.stdin.readline().strip())
+                        new_fontsize = int(click.prompt('Enter new font size (leave empty to abort)'))
                     except:
                         pass
                     if new_fontsize:
@@ -645,6 +646,8 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                             print("Automatic resize of TTY to {} rows, {} columns".format(max_dim[1], max_dim[0]))
                             ptty.set_tty_size(ptty.ttydev(vcsa), max_dim[1], max_dim[0])
                         oldbuff = None
+                    else:
+                        print('Font size not changed')
 
             with open(vcsa, 'rb') as f:
                 with open(vcsudev, 'rb') as vcsu:

--- a/papertty.py
+++ b/papertty.py
@@ -527,7 +527,7 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
     oldcursor = None
     # dirty - should refactor to make this cleaner
     flags = {'scrub_requested': False, 'force_redraw': False}
-
+    
     # handle SIGINT from `systemctl stop` and Ctrl-C
     def sigint_handler(sig, frame):
         if not interactive:
@@ -536,11 +536,11 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                 ptty.showtext(oldbuff, fill=ptty.white, **textargs)
             sys.exit(0)
 
-        print('Enter')
-        print('\t(f) to change font')
-        print('\t(s) to change spacing')
-        print('\t(x) to exit')
-        print('\tanything else to continue.')
+        print('Rendering paused. Enter')
+        print('    (f) to change font,')
+        print('    (s) to change spacing,')
+        print('    (x) to exit,')
+        print('    anything else to continue.')
 
         ch = sys.stdin.readline().strip()
         if ch == 'x':
@@ -598,7 +598,10 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                 max_dim = ptty.fit(portrait)
                 print("Automatic resize of TTY to {} rows, {} columns".format(max_dim[1], max_dim[0]))
                 ptty.set_tty_size(ptty.ttydev(vcsa), max_dim[1], max_dim[0])
-        print("Started displaying {}, minimum update interval {} s, exit with Ctrl-C".format(vcsa, sleep))
+        if interactive:
+            print("Started displaying {}, minimum update interval {} s, open menu with Ctrl-C".format(vcsa, sleep))
+        else:
+            print("Started displaying {}, minimum update interval {} s, exit with Ctrl-C".format(vcsa, sleep))
         character_width, vcsudev = ptty.vcsudev(vcsa)
         while True:
             # if SIGUSR1 toggled the scrub flag, scrub display and start with a fresh image

--- a/papertty.py
+++ b/papertty.py
@@ -375,20 +375,8 @@ class PaperTTY:
     def clear(self):
         """Clears the display; set all black, then all white, or use INIT mode, if driver supports it."""
         if self.ready():
-            if hasattr(self.driver, "DISPLAY_UPDATE_MODE_INIT"):
-                print('Driver supports INIT mode')
-                image = Image.new('1', (self.driver.width, self.driver.height), self.white)
-                self.driver.draw(0, 0, image, self.driver.DISPLAY_UPDATE_MODE_INIT)
-                print('Display reinitialized.')
-            else:
-                print('Driver does not support INIT mode. Blacking and whiting out display instead.')
-                print('Blacking out display ...')
-                image = Image.new('1', (self.driver.width, self.driver.height), self.black)
-                self.driver.draw(0, 0, image)
-                print('... done. Whiting out display ...')
-                image = Image.new('1', (self.driver.width, self.driver.height), self.white)
-                self.driver.draw(0, 0, image)
-                print('... done.')
+            self.driver.clear()
+            print('Display reinitialized.')
         else:
             self.error("Display not ready")
 

--- a/papertty.py
+++ b/papertty.py
@@ -666,6 +666,7 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                                                 **textargs)
                         oldbuff = buff
                         oldcursor = cursor
+                        flags['force_redraw'] = False
                     else:
                         # delay before next update check
                         time.sleep(float(sleep))

--- a/papertty.py
+++ b/papertty.py
@@ -64,14 +64,16 @@ class PaperTTY:
         self.driver = get_drivers()[driver]['class']()
         self.font = self.load_font(font, fontsize) if font else None
         if self.font:
-            # get physical dimensions of font
-            self.font_width = self.font.getsize('M')[0]
+            # get physical dimensions of font. Take the average width of
+            # 1000 M's because oblique fonts a complicated.
+            self.font_width = self.font.getsize('M' * 1000)[0] // 1000
             if 'getmetrics' in dir(self.font):
                 metrics_ascent, metrics_descent = self.font.getmetrics()
                 self.spacing = int(spacing) if spacing != 'auto' else (metrics_descent - 2)
                 print('Setting spacing to {}.'.format(self.spacing))
                 # despite what the PIL docs say, ascent appears to be the
-                # height of the font, while descent is not, in fact, negative
+                # height of the font, while descent is not, in fact, negative.
+                # Couuld use testing with more fonts.
                 self.font_height = metrics_ascent + self.spacing
             else:
                 # No autospacing for pil fonts, but they usually don't need it.

--- a/papertty.py
+++ b/papertty.py
@@ -593,7 +593,7 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                     print('    (h) to change font size,')
                 print('    (x) to exit,')
                 print('    anything else to continue.')
-                print('Use --font {} --size {} --spacing {} for the current setting.'.format(ptty.fontfile, ptty.fontsize, ptty.spacing))
+                print('Command line arguments for current settings:\n    --font {} --size {} --spacing {}'.format(ptty.fontfile, ptty.fontsize, ptty.spacing))
 
                 ch = sys.stdin.readline().strip()
                 if ch == 'x':
@@ -602,10 +602,10 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                     sys.exit(0)
                 elif ch == 'f':
                     print('Current font: {}'.format(ptty.fontfile))
-                    font_name = click.prompt('Enter new font (leave empty to abort)')
-                    if font_name:
+                    new_font = click.prompt('Enter new font (leave empty to abort)', default='', show_default=False)
+                    if new_font:
                         ptty.spacing = spacing
-                        ptty.font = ptty.load_font(font_name, keep_if_not_found=True)
+                        ptty.font = ptty.load_font(new_font, keep_if_not_found=True)
                         if autofit:
                             max_dim = ptty.fit(portrait)
                             print("Automatic resize of TTY to {} rows, {} columns".format(max_dim[1], max_dim[0]))
@@ -615,12 +615,8 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                         print('Font not changed')
                 elif ch == 's':
                     print('Current spacing: {}'.format(ptty.spacing))
-                    new_spacing = None
-                    try:
-                        new_spacing = int(click.prompt('Enter new spacing (leave empty to abort)'))
-                    except:
-                        pass
-                    if new_spacing or new_spacing == 0:
+                    new_spacing = click.prompt('Enter new spacing (leave empty to abort)', default='empty', type=int, show_default=False)
+                    if new_spacing != 'empty':
                         ptty.spacing = new_spacing
                         ptty.recalculate_font()
                         if autofit:
@@ -632,12 +628,8 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                         print('Spacing not changed')
                 elif ch == 'h' and ptty.is_truetype:
                     print('Current font size: {}'.format(ptty.fontsize))
-                    new_fontsize = None
-                    try:
-                        new_fontsize = int(click.prompt('Enter new font size (leave empty to abort)'))
-                    except:
-                        pass
-                    if new_fontsize:
+                    new_fontsize = click.prompt('Enter new font size (leave empty to abort)', default='empty', type=int, show_default=False)
+                    if new_fontsize != 'empty':
                         ptty.fontsize = new_fontsize
                         ptty.spacing = spacing
                         ptty.font = ptty.load_font(path=None)


### PR DESCRIPTION
Tired of restarting PaperTTY every time you want to try a new font? Fear not, for interactive mode has arrived! If started with `--interactive` the Ctrl-C handler gets replaced by a little menu that lets you change font, size and spacing. And also exit the program. Obviously not for use as a service, but very practical to figure out which font works best for your display.

For best results, start with `--autofit`.