### PR TITLE
Fixes for 7in5v2

### DIFF
--- a/drivers/drivers_full.py
+++ b/drivers/drivers_full.py
@@ -451,8 +451,8 @@ class EPD7in5v2(WaveshareFull):
         Mirroring behaviour in reference implementation:
         https://github.com/waveshare/e-Paper/blob/702def06bcb75983c98b0f9d25d43c552c248eb0/RaspberryPi%26JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py#L48-L54
 
-        The `reset` inherited from `WaveshareFull` did not work (`init` hanged at `wait_until_idle` after the `POWER_ON`
-        command was sent.
+        The earlier implementation of `reset` inherited from `WaveshareFull` did not work with some units 
+        (`init` hanged at `wait_until_idle` after the `POWER_ON` command was sent).
 
         A quick scan of the other implementations indicates that the reset varies across devices (it's unclear
         whether there is good reason for device specific differences or if the developer was just being inconsistent...)

--- a/drivers/drivers_full.py
+++ b/drivers/drivers_full.py
@@ -451,7 +451,7 @@ class EPD7in5v2(WaveshareFull):
         Mirroring behaviour in reference implementation:
         https://github.com/waveshare/e-Paper/blob/702def06bcb75983c98b0f9d25d43c552c248eb0/RaspberryPi%26JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py#L48-L54
 
-        The earlier implementation of `reset` inherited from `WaveshareFull` did not work with some units 
+        The earlier implementation of `reset` inherited from `WaveshareFull` did not work with some units
         (`init` hanged at `wait_until_idle` after the `POWER_ON` command was sent).
 
         A quick scan of the other implementations indicates that the reset varies across devices (it's unclear
@@ -477,4 +477,5 @@ class EPD7in5v2(WaveshareFull):
         """
         self.send_command(0x71)
         while self.digital_read(self.BUSY_PIN) == 0:  # 0: busy, 1: idle
+            self.delay_ms(20)
             self.send_command(0x71)


### PR DESCRIPTION
Unfortunately, the 7in5v2 configuration added by @badrihippo didn't work when I tried it on my device; the `reset` inherited from `WaveshareFull` does not seem to play with `wait_until_idle`.

This PR changes the `reset` used for this device to mirror that of the reference implementation: https://github.com/waveshare/e-Paper/blob/702def06bcb75983c98b0f9d25d43c552c248eb0/RaspberryPi%26JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py#L48-L54. A quick scan of the other reference implementations indicates that the reset varies across devices so should prehaps not be common (it's unclear whether there is good reason for device specific differences or if the developer is just being inconsistent most of the time...).

I have also matched the `wait_until_idle` with the device specific implementation in the reference, as it is significantly different to the one that is inheritted.

Lastly, I have removed an undocumented, extraneous "VDHR" data send, which is not in the reference implementation: https://github.com/waveshare/e-Paper/blob/702def06bcb75983c98b0f9d25d43c552c248eb0/RaspberryPi%26JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py#L86-L89. I am very willing to accept that there is good reason for this but I can't work it out!


