### PR TITLE
Give error if `scrub` is used on a screen without partial refresh suppport

### DIFF
--- a/drivers/drivers_base.py
+++ b/drivers/drivers_base.py
@@ -57,6 +57,8 @@ class DisplayDriver(ABC):
 
     def scrub(self, fillsize=16):
         """Scrub display - only works properly with partial refresh"""
+        if not self.supports_partial:
+            raise RuntimeError("scrub only works properly with screens that have partial refresh support")
         self.fill(self.black, fillsize=fillsize)
         self.fill(self.white, fillsize=fillsize)
 


### PR DESCRIPTION
It took me a while to realise why `scrub` didn't work on the device that I have, which doesn't support partial refresh.

This PR aims to make the issue clear to anyone trying the same thing in the future.