### PR TITLE
Add CLI sub-command to display image 

### DIFF
--- a/drivers/drivers_full.py
+++ b/drivers/drivers_full.py
@@ -72,8 +72,8 @@ class WaveshareFull(WaveshareEPD):
         image_monocolor = image.convert('1')
         imwidth, imheight = image_monocolor.size
         if imwidth != self.width or imheight != self.height:
-            raise ValueError('Image must be same dimensions as display \
-                ({0}x{1}).'.format(self.width, self.height))
+            raise ValueError('Image must be same dimensions as display: required ({0}x{1}), got ({2}x{3})'
+                             .format(self.width, self.height, imwidth, imheight))
 
         pixels = image_monocolor.load()
         for y in range(self.height):

--- a/papertty.py
+++ b/papertty.py
@@ -42,6 +42,8 @@ from PIL import Image, ImageChops, ImageDraw, ImageFont, ImageOps
 from collections import OrderedDict
 # for VNC
 from vncdotool import api
+# TODO
+from io import BytesIO
 
 
 class PaperTTY:
@@ -490,6 +492,21 @@ def stdin(settings, font, fontsize, width, portrait, nofold, spacing):
 
 
 @click.command()
+@click.pass_obj
+def image(settings):
+    """ Render image data given on stdin """
+    # XXX: logging to stdout, in line with the rest of this project
+    print("Reading image data from stdin... (this will wait forever if no data is given!)")
+    image_data = BytesIO(sys.stdin.buffer.read())
+
+    image = Image.open(image_data)
+    image = image.resize((800, 480))
+
+    ptty = settings.get_init_tty()
+    ptty.driver.draw(0, 0, image)
+
+
+@click.command()
 @click.option('--host', default="localhost", help="VNC host to connect to", show_default=True)
 @click.option('--display', default="0", help="VNC display to use (0 = port 5900)", show_default=True)
 @click.option('--password', default=None, help="VNC password")
@@ -711,6 +728,7 @@ if __name__ == '__main__':
     cli.add_command(scrub)
     cli.add_command(terminal)
     cli.add_command(stdin)
+    cli.add_command(image)
     cli.add_command(vnc)
     cli.add_command(list_drivers)
     cli()

--- a/papertty.py
+++ b/papertty.py
@@ -451,19 +451,26 @@ def display_image(driver, image, stretch, no_resize, portrait, fill_color):
         image = image.transpose(PIL.Image.ROTATE_90)
     image_width, image_height = image.size
 
-    if (image_width, image_height) != (driver.width, driver.height):
-        if stretch:
-            image = image.resize((driver.width, driver.height))
+    if stretch:
+        if (image_width, image_height) == (driver.width, driver.height):
+            output_image = image
         else:
-            if no_resize and (image_width > driver.width or image_height > driver.height):
+            output_image = image.resize((driver.width, driver.height))
+    else:
+        if no_resize:
+            if image_width > driver.width or image_height > driver.height:
                 raise RuntimeError("Image ({0}x{1}) needs to be resized to fit the screen ({2}x{3})"
                                    .format(image_width, image_height, driver.width, driver.height))
+            # Pad only
+            output_image = Image.new(image.mode, (driver.width, driver.height), color=fill_color)
+            output_image.paste(image, (0, 0))
+        else:
             # Scales and pads
-            image = ImageOps.pad(image, (driver.width, driver.height), color=fill_color)
+            output_image = ImageOps.pad(image, (driver.width, driver.height), color=fill_color)
 
-    driver.draw(0, 0, image)
+    driver.draw(0, 0, output_image)
 
-    return image
+    return output_image
 
 
 @click.group()

--- a/papertty.py
+++ b/papertty.py
@@ -431,7 +431,7 @@ def get_driver_list():
     return '\n'.join(["{}{}".format(driver.ljust(15), order[driver]['desc']) for driver in order])
 
 
-def display_image(driver, image, stretch, no_resize, portrait, fill_color):
+def display_image(driver, image, stretch, no_resize, fill_color):
     """
     Display the given image using the given driver and options.
     :param driver: device driver (subclass of `WaveshareEPD`)
@@ -439,16 +439,12 @@ def display_image(driver, image, stretch, no_resize, portrait, fill_color):
     :param stretch: whether to stretch the image so that it fills the screen in both dimentions
     :param no_resize: whether the image should not be resized if it does not fit the screen (will raise `RuntimeError`
     if image is too large)
-    :param portrait: whether to rotate the image 90 degrees to the left to achieve "portrait orientation" (as defined by
-    this library)
     :param fill_color: colour to fill space when image is resized but one dimension does not fill the screen
     :return: the image that was rendered
     """
     if stretch and no_resize:
-        raise ValueError("Cannot set --no-resize with --stretch")
+        raise ValueError('Cannot set "no-resize" with "stretch"')
 
-    if portrait:
-        image = image.transpose(PIL.Image.ROTATE_90)
     image_width, image_height = image.size
 
     if stretch:
@@ -459,7 +455,7 @@ def display_image(driver, image, stretch, no_resize, portrait, fill_color):
     else:
         if no_resize:
             if image_width > driver.width or image_height > driver.height:
-                raise RuntimeError("Image ({0}x{1}) needs to be resized to fit the screen ({2}x{3})"
+                raise RuntimeError('Image ({0}x{1}) needs to be resized to fit the screen ({2}x{3})'
                                    .format(image_width, image_height, driver.width, driver.height))
             # Pad only
             output_image = Image.new(image.mode, (driver.width, driver.height), color=fill_color)
@@ -554,9 +550,12 @@ def image(settings, image_location, stretch, no_resize, portrait, fill_color):
     else:
         image = Image.open(image_location)
 
+    if portrait:
+        image = image.transpose(PIL.Image.ROTATE_90)
+
     ptty = settings.get_init_tty()
 
-    display_image(ptty.driver, image, stretch, no_resize, portrait, fill_color)
+    display_image(ptty.driver, image, stretch, no_resize, fill_color)
 
 
 @click.command()

--- a/papertty.py
+++ b/papertty.py
@@ -42,10 +42,8 @@ from PIL import Image, ImageChops, ImageDraw, ImageFont, ImageOps
 from collections import OrderedDict
 # for VNC
 from vncdotool import api
-# TODO
+# for reading stdin data for use with Pillow
 from io import BytesIO
-# TODO
-import PIL
 
 
 class PaperTTY:
@@ -431,7 +429,7 @@ def get_driver_list():
     return '\n'.join(["{}{}".format(driver.ljust(15), order[driver]['desc']) for driver in order])
 
 
-def display_image(driver, image, stretch, no_resize, fill_color):
+def display_image(driver, image, stretch=False, no_resize=False, fill_color="white"):
     """
     Display the given image using the given driver and options.
     :param driver: device driver (subclass of `WaveshareEPD`)
@@ -538,20 +536,20 @@ def stdin(settings, font, fontsize, width, portrait, nofold, spacing):
 @click.option('--no-resize', default=False, is_flag=True,
               help='Do not resize image to fit the screen (an error will occur if the image is too large!)')
 @click.option('--portrait', default=False, is_flag=True, help='Use portrait orientation', show_default=True)
-@click.option('--fill-color', default='white', help='Colour to pad resized image with', show_default=True)
+@click.option('--fill-color', default='white', help='Colour to pad image with', show_default=True)
 @click.pass_obj
 def image(settings, image_location, stretch, no_resize, portrait, fill_color):
-    """ Render image data given on stdin """
+    """ Display an image """
     if image_location is None or image_location == '-':
         # XXX: logging to stdout, in line with the rest of this project
-        print('Reading image data from stdin... (set "--image" to load an image using a file path)')
+        print('Reading image data from stdin... (set "--image" to load an image from a given file path)')
         image_data = BytesIO(sys.stdin.buffer.read())
         image = Image.open(image_data)
     else:
         image = Image.open(image_location)
 
     if portrait:
-        image = image.transpose(PIL.Image.ROTATE_90)
+        image = image.transpose(Image.ROTATE_90)
 
     ptty = settings.get_init_tty()
 

--- a/papertty.py
+++ b/papertty.py
@@ -494,6 +494,7 @@ def stdin(settings, font, fontsize, width, portrait, nofold, spacing):
 
 
 @click.command()
+@click.option('--image', 'image_location', help='Location of image to display (omit for stdin)', show_default=True)
 @click.option('--stretch', default=False, is_flag=True,
               help='Stretch image so that it fills the entire screen (may distort your image!)')
 @click.option('--no-resize', default=False, is_flag=True,
@@ -501,17 +502,19 @@ def stdin(settings, font, fontsize, width, portrait, nofold, spacing):
 @click.option('--portrait', default=False, is_flag=True, help='Use portrait orientation', show_default=True)
 @click.option('--fill-color', default='white', help='Colour to pad resized image with', show_default=True)
 @click.pass_obj
-def image(settings, stretch, no_resize, portrait, fill_color):
+def image(settings, image_location, stretch, no_resize, portrait, fill_color):
     """ Render image data given on stdin """
     if stretch and no_resize:
-        # TODO: can this be defined using click?
         raise ValueError("Cannot set --no-resize with --stretch")
 
-    # XXX: logging to stdout, in line with the rest of this project
-    print("Reading image data from stdin... (this will wait forever if no data is given!)")
-    image_data = BytesIO(sys.stdin.buffer.read())
+    if image_location is None or image_location == "-":
+        # XXX: logging to stdout, in line with the rest of this project
+        print("Reading image data from stdin... (set `--image` to load an image using a file path)")
+        image_data = BytesIO(sys.stdin.buffer.read())
+        image = Image.open(image_data)
+    else:
+        image = Image.open(image_location)
 
-    image = Image.open(image_data)
     if portrait:
         image = image.transpose(PIL.Image.ROTATE_90)
     image_width, image_height = image.size

--- a/papertty.py
+++ b/papertty.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+# Colin Nolan, 2020
 # Jouko Strömmer, 2018
 # Copyright and related rights waived via CC0
 # https://creativecommons.org/publicdomain/zero/1.0/legalcode


### PR DESCRIPTION
This PR adds an option to display an image from the CLI, similarly to how text can be displayed.

My main motivation for adding this functionality is to easily draw something to screen (that's more interesting than just text!) when looking into the drivers. It's also enables someone only interested in rendering images to easily benefit from this library.

The new `image` option allows an image (of any type Pillow can deal with) to be loaded from stdin or file path. The image will then be manipulated according to a couple of simple options, before been displayed.
