### PR TITLE
Revert vncdotool to fix bug when using VNC password

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Pillow
 RPi.GPIO
 spidev
 click
-vncdotool
+vncdotool==0.13.0


### PR DESCRIPTION
**TL;DR:**
There is a [known issue](https://github.com/sibson/vncdotool/issues/172) in `vncdotool` version `1.0.0` which breaks the password functionality. This PR would lock that dependency in our virtualenv to the previous working version `0.13.0`.

**Expected behavior:**
When setting a VNC password, I should be able to connect with `papertty.py vnc --password <password>`.

**Actual behavior:**
There is an Unhandled Error from `vncdotool` and the connection is never completed.

**Steps to reproduce:**
1. Follow normal installation instructions, including `mkvirtualenv -p /usr/bin/python3 -r requirements.txt papertty`
1. Set a VNC password upon initial VNC setup (here I'm using the password `3B` as an example) and allow it to be saved to `~/.vnc/passwd`.
1. Start the VNC server (for example, `x11vnc -localhost -shared -usepw -display :0 -forever -bg`
1. Confirm you can access the VNC desktop using that password from other VNC clients.
1. Attempt to start the PaperTTY VNC client:  `sudo ~/.virtualenvs/papertty/bin/python3 papertty.py --driver epd4in2 vnc --display 0 --sleep 0.01 --password 3B` and observe the following output:
```
The font 'tom-thumb.pil' could not be found, using fallback font instead.
Unhandled Error
Traceback (most recent call last):
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/python/log.py", line 103, in callWithLogger
    return callWithContext({"system": lp}, func, *args, **kw)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/python/log.py", line 86, in callWithContext
    return context.call({ILogContext: newCtx}, func, *args, **kw)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/python/context.py", line 122, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/python/context.py", line 85, in callWithContext
    return func(*args,**kw)
--- <exception caught here> ---
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/internet/posixbase.py", line 614, in _doReadOrWrite
    why = selectable.doRead()
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/internet/tcp.py", line 243, in doRead
    return self._dataReceived(data)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/internet/tcp.py", line 249, in _dataReceived
    rval = self.protocol.dataReceived(data)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/rfb.py", line 685, in dataReceived
    self._handler()
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/rfb.py", line 694, in _handleExpected
    self._expected_handler(block, *self._expected_args, **self._expected_kwargs)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/rfb.py", line 255, in _handleVNCAuth
    self.vncRequestPassword()
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/client.py", line 375, in vncRequestPassword
    self.sendPassword(self.factory.password)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/rfb.py", line 261, in sendPassword
    des = RFBDes(pw)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/pyDes.py", line 410, in __init__
    self.setKey(key)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/rfb.py", line 835, in setKey
    if bsrc & (1 << i):
builtins.TypeError: unsupported operand type(s) for &: 'str' and 'int'

Unhandled Error
Traceback (most recent call last):
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/python/log.py", line 103, in callWithLogger
    return callWithContext({"system": lp}, func, *args, **kw)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/python/log.py", line 86, in callWithContext
    return context.call({ILogContext: newCtx}, func, *args, **kw)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/python/context.py", line 122, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/python/context.py", line 85, in callWithContext
    return func(*args,**kw)
--- <exception caught here> ---
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/internet/posixbase.py", line 614, in _doReadOrWrite
    why = selectable.doRead()
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/internet/tcp.py", line 243, in doRead
    return self._dataReceived(data)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/twisted/internet/tcp.py", line 249, in _dataReceived
    rval = self.protocol.dataReceived(data)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/rfb.py", line 685, in dataReceived
    self._handler()
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/rfb.py", line 694, in _handleExpected
    self._expected_handler(block, *self._expected_args, **self._expected_kwargs)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/rfb.py", line 255, in _handleVNCAuth
    self.vncRequestPassword()
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/client.py", line 375, in vncRequestPassword
    self.sendPassword(self.factory.password)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/rfb.py", line 261, in sendPassword
    des = RFBDes(pw)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/pyDes.py", line 410, in __init__
    self.setKey(key)
  File "/home/pi/.virtualenvs/papertty/lib/python3.5/site-packages/vncdotool/rfb.py", line 835, in setKey
    if bsrc & (1 << i):
builtins.TypeError: unsupported operand type(s) for &: 'str' and 'int'
```

**Solution:**
After setting `vncdotool` to the previous version `v0.13.0` in `requirements.txt` and rebuilding my virtualenv, I get the expected behavior.  I recommend specifying that version until `vncdotool` releases a stable fix for https://github.com/sibson/vncdotool/issues/172.