### PR TITLE
Made imports of GPIO fail less disruptively on non-Pi systems.

### DIFF
--- a/drivers/driver_it8951.py
+++ b/drivers/driver_it8951.py
@@ -8,6 +8,8 @@ try:
     import RPi.GPIO as GPIO
 except ImportError:
     pass
+except RuntimeError as e:
+    print(str(e))
 
 class IT8951(DisplayDriver):
     """A generic driver for displays that use a IT8951 controller board.

--- a/drivers/drivers_4in2.py
+++ b/drivers/drivers_4in2.py
@@ -23,6 +23,8 @@ try:
     import RPi.GPIO as GPIO
 except ImportError:
     pass
+except RuntimeError as e:
+    print(str(e))
 
 # The driver works as follows:
 #

--- a/drivers/drivers_base.py
+++ b/drivers/drivers_base.py
@@ -26,6 +26,8 @@ try:
     import RPi.GPIO as GPIO
 except ImportError:
     pass
+except RuntimeError as e:
+    print(str(e))
 
 
 class DisplayDriver(ABC):


### PR DESCRIPTION
GPIO fails with RuntimeError if not running on a Raspberry Pi. However, it is not needed for Dummy and Bitmap drivers, so should not bring down the whole program.