### PR TITLE
Font height fix

### DIFF
--- a/papertty/papertty.py
+++ b/papertty/papertty.py
@@ -398,11 +398,10 @@ class PaperTTY:
             # Split the text up by line and display each line individually.
             # This is a workaround for a font height bug in PIL
             lines = text.split('\n')
-            for i in range(self.rows):
-                line = lines[i] if i < len(lines) else ''
-                y = i * self.font_height
+            for i, line in enumerate(lines):
                 if line:
-                     draw.text((0, y), line, font=self.font, fill=fill, spacing=self.spacing)
+                    y = i * self.font_height
+                    draw.text((0, y), line, font=self.font, fill=fill, spacing=self.spacing)
 
             # if we want a cursor, draw it - the most convoluted part
             if cursor and self.cursor:

--- a/papertty/papertty.py
+++ b/papertty/papertty.py
@@ -401,7 +401,8 @@ class PaperTTY:
             for i in range(self.rows):
                 line = lines[i] if i < len(lines) else ''
                 y = i * self.font_height
-                draw.text((0, y), line, font=self.font, fill=fill, spacing=self.spacing)
+                if line:
+                     draw.text((0, y), line, font=self.font, fill=fill, spacing=self.spacing)
 
             # if we want a cursor, draw it - the most convoluted part
             if cursor and self.cursor:

--- a/papertty/papertty.py
+++ b/papertty/papertty.py
@@ -222,7 +222,7 @@ class PaperTTY:
             # despite what the PIL docs say, ascent appears to be the
             # height of the font, while descent is not, in fact, negative.
             # Couuld use testing with more fonts.
-            self.font_height = metrics_ascent + self.spacing
+            self.font_height = metrics_ascent + metrics_descent + self.spacing
         else:
             # No autospacing for pil fonts, but they usually don't need it.
             self.spacing = int(self.spacing) if self.spacing != 'auto' else 0
@@ -394,7 +394,14 @@ class PaperTTY:
                               self.white)
             # create the Draw object and draw the text
             draw = ImageDraw.Draw(image)
-            draw.text((0, 0), text, font=self.font, fill=fill, spacing=self.spacing)
+
+            # Split the text up by line and display each line individually.
+            # This is a workaround for a font height bug in PIL
+            lines = text.split('\n')
+            for i in range(self.rows):
+                line = lines[i] if i < len(lines) else ''
+                y = i * self.font_height
+                draw.text((0, y), line, font=self.font, fill=fill, spacing=self.spacing)
 
             # if we want a cursor, draw it - the most convoluted part
             if cursor and self.cursor:

--- a/papertty/papertty.py
+++ b/papertty/papertty.py
@@ -206,33 +206,17 @@ class PaperTTY:
             font = ImageFont.load_default()
 
         if font:
-            # get physical dimensions of font. Take the average width of
-            # 1000 M's because oblique fonts are complicated.
-            self.font_width = font.getsize('M' * 1000)[0] // 1000
-            if 'getmetrics' in dir(font):
-                metrics_ascent, metrics_descent = font.getmetrics()
-                self.spacing = int(self.spacing) if self.spacing != 'auto' else (metrics_descent - 2)
-                print('Setting spacing to {}.'.format(self.spacing))
-                # despite what the PIL docs say, ascent appears to be the
-                # height of the font, while descent is not, in fact, negative.
-                # Couuld use testing with more fonts.
-                self.font_height = metrics_ascent + self.spacing
-            else:
-                # No autospacing for pil fonts, but they usually don't need it.
-                self.spacing = int(self.spacing) if self.spacing != 'auto' else 0
-                # pil fonts don't seem to have metrics, but all
-                # characters seem to have the same height
-                self.font_height = font.getsize('a')[1] + self.spacing
+            self.recalculate_font(font)
 
         return font
 
-    def recalculate_font(self):
+    def recalculate_font(self, font):
         """Load the PIL or TrueType font"""
         # get physical dimensions of font. Take the average width of
         # 1000 M's because oblique fonts a complicated.
-        self.font_width = self.font.getsize('M' * 1000)[0] // 1000
-        if 'getmetrics' in dir(self.font):
-            metrics_ascent, metrics_descent = self.font.getmetrics()
+        self.font_width = font.getsize('M' * 1000)[0] // 1000
+        if 'getmetrics' in dir(font):
+            metrics_ascent, metrics_descent = font.getmetrics()
             self.spacing = int(self.spacing) if self.spacing != 'auto' else (metrics_descent - 2)
             print('Setting spacing to {}.'.format(self.spacing))
             # despite what the PIL docs say, ascent appears to be the
@@ -244,7 +228,7 @@ class PaperTTY:
             self.spacing = int(self.spacing) if self.spacing != 'auto' else 0
             # pil fonts don't seem to have metrics, but all
             # characters seem to have the same height
-            self.font_height = self.font.getsize('a')[1] + self.spacing
+            self.font_height = font.getsize('a')[1] + self.spacing
 
     def init_display(self):
         """Initialize the display - call the driver's init method"""
@@ -788,7 +772,7 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                     new_spacing = click.prompt('Enter new spacing (leave empty to abort)', default='empty', type=int, show_default=False)
                     if new_spacing != 'empty':
                         ptty.spacing = new_spacing
-                        ptty.recalculate_font()
+                        ptty.recalculate_font(ptty.font)
                         if autofit:
                             max_dim = ptty.fit(portrait)
                             print("Automatic resize of TTY to {} rows, {} columns".format(max_dim[1], max_dim[0]))


### PR DESCRIPTION
This PR contains two commits.
The first is simply to reduce repeat code, where recalculate_font was almost identical to another code block.
The other is to work around a bug in PIL's font height calculation.

PaperTTY currently uses PIL 7.1.2.
PIL 8.0.0 introduced a method for retrieving the bbox of a font, so that can be used to more accurately get the size of a font
PIL 10.0.0 removed getsize altogether in favor of using bbox due to problems with the old method

As for how this relates to PaperTTY, the version and manner in which PIL is being used has caused an issue with some fonts in terminal mode.
More specifically, the text draw command in PIL 7.1.2 isn't taking the font descent into account properly, in some cases causing text overlap.

For example, I've been testing this with UbuntuMono-R font at size 24 on the 10.3" e-paper waveshare screen.
I get text overlap when typing "g" on one line and "b" on the next.
I've tested other sizes and fonts and observed the same overlap.

I suspect that someone already noticed this problem and that is how the "auto" spacing ended up with the value of
`metrics_descent - 2`
and the font height was calculated as
`self.font_height = metrics_ascent + self.spacing`
Those two together roughly match the actual font height and somewhat works around the PIL bug.
You can see a visual representation of how ascent, descent, etc. work in PIL here:
https://stackoverflow.com/questions/43060479/how-to-get-the-font-pixel-height-using-pils-imagefont-class

The currently approach mostly works.
However, the default spacing for terminal mode is 0, not auto.
And even in auto mode, -2 is only accurate for certain font sizes.
This means that trial and error is currently necessary to get the right sizing for a particular font and font size combination.

This PR attempts to fix the problem by doing two things.
1. metrics_descent is added to the font height calculation, so the font height is no longer just the ascent
2. PIL's text draw method is put in a loop and drawn onto the image object line by line. This puts responsibility for positioning onto PaperTTY instead of PIL, thus preventing its font height calculation from causing overlap

I haven't encountered any issues with this approach during my own testing, nor did I find any measurable performance impact from the change to the draw behavior.
It still only performs one draw to the screen, after all. It's just the manner in which text is placed on the image which has changed.

One side-effect that is worth mentioning, however, is that text won't seem as compact as before, since the text is no longer overlapping.
You can still make it more compact by setting the spacing as a negative value to reintroduce overlap.
Also, if this PR is merged, it might be worth revising the "auto" spacing, since the old value won't be as relevant anymore.