### PR TITLE
vcom command line argument for IT8951

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Option | Description | Default
 `--spacing` | Set line spacing | `0` 
 `--scrub` | Apply scrub when starting | disabled
 `--autofit` | Try to automatically set terminal rows/cols for the font | disabled
+`--vcom` | Set the VCOM value of the panel. Entered as positive value x 1000. eg. 1460 = -1.46V | *no default*
 
 
 ```sh

--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -173,7 +173,7 @@ class IT8951(DisplayDriver):
             result = result[0:null_index]
         return result
 
-    def init(self, vcom=None, **kwargs):
+    def init(self, **kwargs):
         GPIO.setmode(GPIO.BCM)
         GPIO.setwarnings(False)
         GPIO.setup(self.RST_PIN, GPIO.OUT)
@@ -228,8 +228,9 @@ class IT8951(DisplayDriver):
         # Set to Enable I80 Packed mode.
         self.write_register(self.REG_I80CPCR, 0x0001)
 
-        if vcom:
-            self.VCOM = vcom
+        for key, value in kwargs.items():
+            if key == 'vcom':
+                self.VCOM = value
             
         if self.VCOM != self.get_vcom():
             self.set_vcom(self.VCOM)

--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -173,7 +173,7 @@ class IT8951(DisplayDriver):
             result = result[0:null_index]
         return result
 
-    def init(self, **kwargs):
+    def init(self, vcom=None, **kwargs):
         GPIO.setmode(GPIO.BCM)
         GPIO.setwarnings(False)
         GPIO.setup(self.RST_PIN, GPIO.OUT)
@@ -228,6 +228,9 @@ class IT8951(DisplayDriver):
         # Set to Enable I80 Packed mode.
         self.write_register(self.REG_I80CPCR, 0x0001)
 
+        if vcom:
+            self.VCOM = vcom
+            
         if self.VCOM != self.get_vcom():
             self.set_vcom(self.VCOM)
             print("VCOM = -%.02fV" % (self.get_vcom() / 1000.0))

--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -228,9 +228,7 @@ class IT8951(DisplayDriver):
         # Set to Enable I80 Packed mode.
         self.write_register(self.REG_I80CPCR, 0x0001)
 
-        for key, value in kwargs.items():
-            if key == 'vcom':
-                self.VCOM = value
+        self.VCOM = kwargs.get('vcom', self.VCOM)
             
         if self.VCOM != self.get_vcom():
             self.set_vcom(self.VCOM)

--- a/papertty/papertty.py
+++ b/papertty/papertty.py
@@ -693,8 +693,7 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
         if vcom <= 0:
             print("VCOM should be a positive number. It will be converted automatically. eg. For a value of -1.46V, set VCOM to 1460")
             sys.exit(1)
-        else:
-            settings.args['vcom'] = vcom
+        settings.args['vcom'] = vcom
 
     if cursor == 'default' or cursor == 'legacy':
         settings.args['cursor'] = 'default'

--- a/papertty/papertty.py
+++ b/papertty/papertty.py
@@ -71,7 +71,7 @@ class PaperTTY:
     is_truetype = None
     fontfile = None
 
-    def __init__(self, driver, font=defaultfont, fontsize=defaultsize, partial=None, encoding='utf-8', spacing=0, cursor=None):
+    def __init__(self, driver, font=defaultfont, fontsize=defaultsize, partial=None, encoding='utf-8', spacing=0, cursor=None, vcom=None):
         """Create a PaperTTY with the chosen driver and settings"""
         self.driver = get_drivers()[driver]['class']()
         self.spacing = spacing
@@ -82,6 +82,7 @@ class PaperTTY:
         self.black = self.driver.black
         self.encoding = encoding
         self.cursor = cursor
+        self.vcom = vcom
 
     def ready(self):
         """Check that the driver is loaded and initialized"""
@@ -693,7 +694,7 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
             print("VCOM should be a positive number. It will be converted automatically. eg. For a value of -1.46V, set VCOM to 1460")
             sys.exit(1)
         else:
-            self.vcom = vcom
+            settings.args['vcom'] = vcom
 
     if cursor == 'default' or cursor == 'legacy':
         settings.args['cursor'] = 'default'


### PR DESCRIPTION
This PR adds a new command line argument, --vcom, to allow people to adjust the VCOM value of the IT8951 driver without manually editing the code.

VCOM is currently hard-coded to -2.0V.
However, ideally it should be set to the value found on the panel's tag.
The reason for this is explained in the waveshare wiki:
https://www.waveshare.com/wiki/7.8inch_e-Paper_HAT#Use_Correct_VCOM_Value

Unfortunately, this value may differ from panel to panel, even if two panels are exactly the same model.
eg. https://www.waveshare.com/wiki/7.8inch_e-Paper_HAT#/media/File:6inch-HD-e-Paper-HAT-Manual-06.png
From waveshare's wiki, those are two of the same 6" panel, both with different VCOM values (-1.5V, -1.78V) so we can't infer the value from the model name.
So while a command line argument isn't ideal, it seems better than needing to manually edit the driver file.