### PR TITLE
Replace initial draw with call to the clear function.

### DIFF
--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -234,8 +234,7 @@ class IT8951(DisplayDriver):
 
         # Initialize the display with a blank image.
         self.wait_for_ready()
-        image = Image.new("L", (self.width, self.height), 0x255)
-        self.draw(0, 0, image, self.DISPLAY_UPDATE_MODE_INIT)
+        self.clear()
 
     def display_area(self, x, y, w, h, display_mode):
         self.write_command(self.CMD_DISPLAY_AREA)


### PR DESCRIPTION
Tiny change to panel initialization for IT8951 driver.
The code at the end of the initialization does the same thing as the clear function, except it does so less efficiently because it uses image mode "L" (grayscale) instead of mode "1" (black & white).
Replacing those two lines of code reduces repeat code and makes it slightly faster because of the different image mode.