### PR TITLE
vcom fix

### DIFF
--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -228,7 +228,9 @@ class IT8951(DisplayDriver):
         # Set to Enable I80 Packed mode.
         self.write_register(self.REG_I80CPCR, 0x0001)
 
-        self.VCOM = kwargs.get('vcom', self.VCOM)
+        vcom = kwargs.get('vcom', None)
+        if vcom:
+            self.VCOM = vcom
             
         if self.VCOM != self.get_vcom():
             self.set_vcom(self.VCOM)


### PR DESCRIPTION
This fixes a bug with the recently merged --vcom flag.

The problem is that self.vcom in papertty.py is initialized as None by default, so it gets passed through as None to the above command if it isn't specified, or if using a mode other than terminal.
It is now checked in the driver to make sure it's set.