### PR TITLE
It8951 1bpp mode, A2 refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,8 @@ Option | Description | Default
 `--scrub` | Apply scrub when starting | disabled
 `--autofit` | Try to automatically set terminal rows/cols for the font | disabled
 `--vcom` | Set the VCOM value of the panel. Entered as positive value x 1000. eg. 1460 = -1.46V | *no default*
+`--disable_a2` | Disable fast A2 panel refresh for black and white images | disabled
+`--disable_1bpp` | Disable fast 1bpp mode | disabled
 
 
 ```sh

--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -260,7 +260,7 @@ class IT8951(DisplayDriver):
         self.write_command(self.CMD_LOAD_IMAGE_AREA)
         self.write_data_half_word(
                 (self.LOAD_IMAGE_L_ENDIAN << 8) |
-                (self.BPP_4 << 4) |
+                (self.BPP_2 << 4) |
                 self.ROTATE_0)
         self.write_data_half_word(x)
         self.write_data_half_word(y)
@@ -301,24 +301,28 @@ class IT8951(DisplayDriver):
             # The driver board assumes all data is read in as 16bit ints. To match
             # the endianness every pair of bytes must be swapped.
             # The image is always padded to a multiple of 8, so we can safely go in steps of 4.
-            for i in range(0, len(frame_buffer), 4):
-                if frame_buffer[i + 2] and frame_buffer[i + 3]:
-                    packed_buffer += [0xFF]
-                elif frame_buffer[i + 2]:
-                    packed_buffer += [0x0F]
-                elif frame_buffer[i + 3]:
-                    packed_buffer += [0xF0]
-                else:
-                    packed_buffer += [0]
+            for i in range(0, len(frame_buffer), 8):
+                thisbit = 0
+                if frame_buffer[i+7]:
+                    thisbit |= 0xC0
+                if frame_buffer[i+6]:
+                    thisbit |= 0x30
+                if frame_buffer[i+5]:
+                    thisbit |= 0xC
+                if frame_buffer[i+4]:
+                    thisbit |= 0x3
+                packed_buffer += [thisbit]
+                thisbit = 0
+                if frame_buffer[i+3]:
+                    thisbit |= 0xC0 
+                if frame_buffer[i+2]:
+                    thisbit |= 0x30
+                if frame_buffer[i+1]:
+                    thisbit |= 0xC
+                if frame_buffer[i+0]:
+                    thisbit |= 0x3
+                packed_buffer += [thisbit]
 
-                if frame_buffer[i] and frame_buffer[i + 1]:
-                    packed_buffer += [0xFF]
-                elif frame_buffer[i]:
-                    packed_buffer += [0x0F]
-                elif frame_buffer[i + 1]:
-                    packed_buffer += [0xF0]
-                else:
-                    packed_buffer += [0]
             return packed_buffer
         else:
             # old packing code for grayscale (VNC)

--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -283,7 +283,7 @@ class IT8951(DisplayDriver):
         #Adjust screen size to accommodate 32px bounding in 1bpp mode
         #Do this AFTER clearing the screen
         self.width -= (self.width % 32)
-        self.height -= (self.height % 32)
+        self.height -= (self.height % 16)
 
         print("adjusted width = %d" % self.width)
         print("adjusted height = %d" % self.height)
@@ -306,7 +306,7 @@ class IT8951(DisplayDriver):
         #Otherwise, set to 4bpp.
         if width == self.width and height == self.height:
             bpp = 1
-        elif width % 32 == 0 and height % 32 == 0:
+        elif width % 32 == 0 and height % 16 == 0:
             bpp = 1
         else:
             bpp = 4

--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -296,6 +296,7 @@ class IT8951(DisplayDriver):
         self.write_data_half_word(h)
         self.write_data_half_word(display_mode)
 
+    def draw(self, x, y, image, update_mode_override=None):
         width = image.size[0]
         height = image.size[1]
 

--- a/papertty/drivers/drivers_base.py
+++ b/papertty/drivers/drivers_base.py
@@ -46,6 +46,10 @@ class DisplayDriver(ABC):
         self.type = None
         self.supports_partial = None
         self.partial_refresh = None
+        self.supports_1bpp = None
+        self.enable_1bpp = None
+        self.align_1bpp_width = None
+        self.align_1bpp_height = None
 
     @abstractmethod
     def init(self, **kwargs):

--- a/papertty/drivers/drivers_full.py
+++ b/papertty/drivers/drivers_full.py
@@ -48,6 +48,10 @@ class WaveshareFull(WaveshareEPD):
         self.supports_partial = False
         self.colors = 2
         self.lut = None
+        self.supports_1bpp = False
+        self.enable_1bpp = False
+        self.align_1bpp_width = False
+        self.align_1bpp_height = False
 
     def wait_until_idle(self):
         while self.digital_read(self.BUSY_PIN) == 0:  # 0: busy, 1: idle

--- a/papertty/papertty.py
+++ b/papertty/papertty.py
@@ -70,6 +70,7 @@ class PaperTTY:
     cols = None
     is_truetype = None
     fontfile = None
+    bpp = 4
 
     def __init__(self, driver, font=defaultfont, fontsize=defaultsize, partial=None, encoding='utf-8', spacing=0, cursor=None, vcom=None):
         """Create a PaperTTY with the chosen driver and settings"""
@@ -703,6 +704,9 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
         settings.args['cursor'] = cursor
 
     ptty = settings.get_init_tty()
+
+    isIt8951 = isinstance(ptty.driver, driver_it8951.IT8951)
+    ptty.bpp = 1 if isIt8951 else 4
 
     if apply_scrub:
         ptty.driver.scrub()

--- a/papertty/papertty.py
+++ b/papertty/papertty.py
@@ -432,7 +432,7 @@ class PaperTTY:
                 # make the X coordinates divisible by 8
                 if self.bpp == 1:
                     xdiv = 32
-                    ydiv = 32
+                    ydiv = 16
                 else:
                     xdiv = 8
                     ydiv = 1

--- a/papertty/papertty.py
+++ b/papertty/papertty.py
@@ -635,6 +635,10 @@ def image(settings, image_location, stretch, no_resize, fill_color, mirror, flip
         image = Image.open(image_data)
     else:
         image = Image.open(image_location)
+    
+    #Disable 1bpp and a2 by default if not using terminal mode
+    settings.args['enable_a2'] = False
+    settings.args['enable_1bpp'] = False
 
     ptty = settings.get_init_tty()
     display_image(ptty.driver, image, stretch=stretch, no_resize=no_resize, fill_color=fill_color, rotate=rotate, mirror=mirror, flip=flip)
@@ -651,6 +655,11 @@ def image(settings, image_location, stretch, no_resize, fill_color, mirror, flip
 @click.pass_obj
 def vnc(settings, host, display, password, rotate, invert, sleep, fullevery):
     """Display a VNC desktop"""
+    
+    #Disable 1bpp and a2 by default if not using terminal mode
+    settings.args['enable_a2'] = False
+    settings.args['enable_1bpp'] = False
+
     ptty = settings.get_init_tty()
     ptty.showvnc(host, display, password, int(rotate) if rotate else None, invert, sleep, fullevery)
 

--- a/papertty/papertty.py
+++ b/papertty/papertty.py
@@ -111,7 +111,7 @@ class PaperTTY:
     def band(bb, xdiv = 8, ydiv = 1):
         """Stretch a bounding box's X coordinates to be divisible by 8,
            otherwise weird artifacts occur as some bits are skipped."""
-        print("Before band: "+str(bb))
+        #print("Before band: "+str(bb))
         return ( \
             int(bb[0] / xdiv) * xdiv, \
             int(bb[1] / ydiv) * ydiv, \

--- a/papertty/papertty.py
+++ b/papertty/papertty.py
@@ -108,10 +108,16 @@ class PaperTTY:
                 print("Try setting a sane size manually.")
 
     @staticmethod
-    def band(bb):
+    def band(bb, xdiv = 8, ydiv = 1):
         """Stretch a bounding box's X coordinates to be divisible by 8,
            otherwise weird artifacts occur as some bits are skipped."""
-        return (int(bb[0] / 8) * 8, bb[1], int((bb[2] + 7) / 8) * 8, bb[3]) if bb else None
+        print("Before band: "+str(bb))
+        return ( \
+            int(bb[0] / xdiv) * xdiv, \
+            int(bb[1] / ydiv) * ydiv, \
+            int((bb[2] + xdiv - 1) / xdiv) * xdiv, \
+            int((bb[3] + ydiv - 1) / ydiv) * ydiv \
+        ) if bb else None
 
     @staticmethod
     def split(s, n):
@@ -424,7 +430,13 @@ class PaperTTY:
             if oldimage and self.driver.supports_partial and self.partial:
                 # create a bounding box of the altered region and
                 # make the X coordinates divisible by 8
-                diff_bbox = self.band(self.img_diff(image, oldimage))
+                if self.bpp == 1:
+                    xdiv = 32
+                    ydiv = 32
+                else:
+                    xdiv = 8
+                    ydiv = 1
+                diff_bbox = self.band(self.img_diff(image, oldimage), xdiv=xdiv, ydiv=ydiv)
                 # crop the altered region and draw it on the display
                 if diff_bbox:
                     self.driver.draw(diff_bbox[0], diff_bbox[1], image.crop(diff_bbox))


### PR DESCRIPTION
This PR adds support for 1bpp mode and A2 display refresh mode for the IT8951 driver.

It also adds 2bpp mode, but doesn't currently utilize it.

2 new flags have been added: --disable_a2 and --disable_1bpp
I went with --disable instead of --enable because they're on by default, so you'd only specify the flag if you wanted to disable them.

1bpp mode also has certain requirements around where the x and y coordinates land, and what size the image is. So the "band" method has been updated to accommodate boundaries other than the default of 8 for the x axis.

Anyway, 1bpp mode means that black and white images can be displayed with a much smaller SPI write. It uses 75% less bytes than the previous default (4bpp), so writes should be 4x as fast. This isn't noticeable for small writes (eg. single line changes), but it is noticeable for bigger writes (eg. full screen changes), especially on devices which can't write data over the pins as quickly.

A2 refresh mode is a faster update mode for 1bpp images.
Per https://www.waveshare.com/w/upload/c/c4/E-paper-mode-declaration.pdf
DU mode has a typical update time of 260ms.
A2 mode has a typical update time of 120ms.
*Note that it is currently disabled for the 6" panel because that particular panel has extra requirements for A2 mode (four-byte alignment) per comments in the code, and I don't have one of those panels to test with.