### PR TITLE
Terminal partial redraw overhaul

### DIFF
--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -313,9 +313,9 @@ class IT8951(DisplayDriver):
         smallest_y = -1
         biggest_y = -1
         for arrayItem in imageArray:
-            left = arrayItem[0]
-            top = arrayItem[1]
-            image = arrayItem[2]
+            left = arrayItem["x"]
+            top = arrayItem["y"]
+            image = arrayItem["image"]
             right = left + image.width
             bottom = top + image.height
             if left < smallest_x or smallest_x == -1:
@@ -329,9 +329,9 @@ class IT8951(DisplayDriver):
         bbox = (smallest_x, smallest_y, biggest_x, biggest_y)
 
         for i, arrayItem in enumerate(imageArray):
-            x = arrayItem[0]
-            y = arrayItem[1]
-            image = arrayItem[2]
+            x = arrayItem["x"]
+            y = arrayItem["y"]
+            image = arrayItem["image"]
             update_mode_override = None
             isFirst = i == 0
             isLast = i == len(imageArray) - 1

--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -308,6 +308,11 @@ class IT8951(DisplayDriver):
         self.write_data_half_word(display_mode)
 
     def draw_multi(self, imageArray):
+
+        """This function performs multiple draws in a single panel refresh"""
+
+        #First, calculate the bounds of the panel area which is being refreshed.
+        #ie. a rectangle within which all of the images in imageArray would fit.
         smallest_x = -1
         biggest_x = -1
         smallest_y = -1
@@ -328,6 +333,7 @@ class IT8951(DisplayDriver):
                 biggest_y = bottom
         bbox = (smallest_x, smallest_y, biggest_x, biggest_y)
 
+        #Next, draw each image.
         for i, arrayItem in enumerate(imageArray):
             x = arrayItem["x"]
             y = arrayItem["y"]
@@ -341,6 +347,7 @@ class IT8951(DisplayDriver):
         width = image.size[0]
         height = image.size[1]
 
+        #If this is the first (or only) image to draw, prepare the display.
         if isFirst:
             self.wait_for_display_ready()
 
@@ -368,7 +375,9 @@ class IT8951(DisplayDriver):
             #Confusingly, 1bpp actually requires the use of the 8bpp flag
             bpp_mode = self.BPP_8
 
+            #If this is the first (or only) image to draw, write the registers.
             if isFirst:
+
                 #If the panel isn't already in 1bpp mode, write these specific commands to the
                 #register to put it into 1bpp mode.
                 #This is the important bit which actually puts it in 1bpp in spite of the 8bpp flag
@@ -390,7 +399,9 @@ class IT8951(DisplayDriver):
             bpp = 4
             bpp_mode = self.BPP_4
 
+            #If this is the first (or only) image to draw, write the registers.
             if isFirst:
+
                 #If the last write was in 1bpp mode, unset that register to take it out of 1bpp mode.
                 if self.in_bpp1_mode:
                     self.write_register(self.REG_UP1SR+2, self.read_register(self.REG_UP1SR+2) & ~(1<<2) )
@@ -418,7 +429,9 @@ class IT8951(DisplayDriver):
         self.write_data_bytes(packed_image)
         self.write_command(self.CMD_LOAD_IMAGE_END);
 
+        #If this is the last (or only) image to draw, refresh the panel.
         if isLast:
+
             if update_mode_override is not None:
                 update_mode = update_mode_override
             elif image.mode == "1":
@@ -431,7 +444,11 @@ class IT8951(DisplayDriver):
             else:
                 # Use a slower, flashy update mode for gray scale images.
                 update_mode = self.DISPLAY_UPDATE_MODE_GC16
-            # Blit the image to the display
+
+            # Blit the image to the display.
+            # If bbox has been passed in (eg. if performing multiple draws at once)
+            # then we should update that area.
+            # Otherwise, refresh the panel based on the image's bounds.
             if bbox:
                 (left, top, right, bottom) = bbox
                 self.display_area(left, top, right-left, bottom-top, update_mode)

--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -87,6 +87,7 @@ class IT8951(DisplayDriver):
         self.enable_1bpp = True
         self.align_1bpp_width = 32
         self.align_1bpp_height = 16
+        self.supports_multi_draw = True
 
     def delay_ms(self, delaytime):
         time.sleep(float(delaytime) / 1000.0)
@@ -306,11 +307,42 @@ class IT8951(DisplayDriver):
         self.write_data_half_word(h)
         self.write_data_half_word(display_mode)
 
-    def draw(self, x, y, image, update_mode_override=None):
+    def draw_multi(self, imageArray):
+        smallest_x = -1
+        biggest_x = -1
+        smallest_y = -1
+        biggest_y = -1
+        for arrayItem in imageArray:
+            left = arrayItem[0]
+            top = arrayItem[1]
+            image = arrayItem[2]
+            right = left + image.width
+            bottom = top + image.height
+            if left < smallest_x or smallest_x == -1:
+                smallest_x = left
+            if right > biggest_x or biggest_x == -1:
+                biggest_x = right
+            if top < smallest_y or smallest_y == -1:
+                smallest_y = top
+            if bottom > biggest_y or biggest_y == -1:
+                biggest_y = bottom
+        bbox = (smallest_x, smallest_y, biggest_x, biggest_y)
+
+        for i, arrayItem in enumerate(imageArray):
+            x = arrayItem[0]
+            y = arrayItem[1]
+            image = arrayItem[2]
+            update_mode_override = None
+            isFirst = i == 0
+            isLast = i == len(imageArray) - 1
+            self.draw(x, y, image, update_mode_override, isFirst, isLast, bbox)
+
+    def draw(self, x, y, image, update_mode_override=None, isFirst=True, isLast=True, bbox=None):
         width = image.size[0]
         height = image.size[1]
 
-        self.wait_for_display_ready()
+        if isFirst:
+            self.wait_for_display_ready()
 
         #Set to 4bpp by default
         bpp = 4
@@ -336,15 +368,16 @@ class IT8951(DisplayDriver):
             #Confusingly, 1bpp actually requires the use of the 8bpp flag
             bpp_mode = self.BPP_8
 
-            #If the panel isn't already in 1bpp mode, write these specific commands to the
-            #register to put it into 1bpp mode.
-            #This is the important bit which actually puts it in 1bpp in spite of the 8bpp flag
-            if not self.in_bpp1_mode:
-                self.write_register(self.REG_UP1SR+2, self.read_register(self.REG_UP1SR+2) | (1<<2) )
-                self.in_bpp1_mode = True
-            
-            #Also write the black and white color table for 1bpp mode
-            self.write_register(self.REG_BGVR, (self.Front_Gray_Val<<8) | self.Back_Gray_Val)
+            if isFirst:
+                #If the panel isn't already in 1bpp mode, write these specific commands to the
+                #register to put it into 1bpp mode.
+                #This is the important bit which actually puts it in 1bpp in spite of the 8bpp flag
+                if not self.in_bpp1_mode:
+                    self.write_register(self.REG_UP1SR+2, self.read_register(self.REG_UP1SR+2) | (1<<2) )
+                    self.in_bpp1_mode = True
+                
+                #Also write the black and white color table for 1bpp mode
+                self.write_register(self.REG_BGVR, (self.Front_Gray_Val<<8) | self.Back_Gray_Val)
 
         else:
             #If we're not in 1bpp mode, default to 4bpp.
@@ -357,15 +390,16 @@ class IT8951(DisplayDriver):
             bpp = 4
             bpp_mode = self.BPP_4
 
-            #If the last write was in 1bpp mode, unset that register to take it out of 1bpp mode.
-            if self.in_bpp1_mode:
-                self.write_register(self.REG_UP1SR+2, self.read_register(self.REG_UP1SR+2) & ~(1<<2) )
-                self.in_bpp1_mode = False
+            if isFirst:
+                #If the last write was in 1bpp mode, unset that register to take it out of 1bpp mode.
+                if self.in_bpp1_mode:
+                    self.write_register(self.REG_UP1SR+2, self.read_register(self.REG_UP1SR+2) & ~(1<<2) )
+                    self.in_bpp1_mode = False
 
-            #Then write the expected registers for 4bpp mode.
-            self.write_register(
-                    self.REG_MEMORY_CONV_LISAR + 2, (self.img_addr >> 16) & 0xFFFF)
-            self.write_register(self.REG_MEMORY_CONV_LISAR, self.img_addr & 0xFFFF)
+                #Then write the expected registers for 4bpp mode.
+                self.write_register(
+                        self.REG_MEMORY_CONV_LISAR + 2, (self.img_addr >> 16) & 0xFFFF)
+                self.write_register(self.REG_MEMORY_CONV_LISAR, self.img_addr & 0xFFFF)
 
         # Define the region being loaded.
         self.write_command(self.CMD_LOAD_IMAGE_AREA)
@@ -384,20 +418,25 @@ class IT8951(DisplayDriver):
         self.write_data_bytes(packed_image)
         self.write_command(self.CMD_LOAD_IMAGE_END);
 
-        if update_mode_override is not None:
-            update_mode = update_mode_override
-        elif image.mode == "1":
-            # Use a faster, non-flashy update mode for pure black and white
-            # images.
-            if bpp == 1 and self.supports_a2 and self.enable_a2:
-                update_mode = self.DISPLAY_UPDATE_MODE_A2
+        if isLast:
+            if update_mode_override is not None:
+                update_mode = update_mode_override
+            elif image.mode == "1":
+                # Use a faster, non-flashy update mode for pure black and white
+                # images.
+                if bpp == 1 and self.supports_a2 and self.enable_a2:
+                    update_mode = self.DISPLAY_UPDATE_MODE_A2
+                else:
+                    update_mode = self.DISPLAY_UPDATE_MODE_DU
             else:
-                update_mode = self.DISPLAY_UPDATE_MODE_DU
-        else:
-            # Use a slower, flashy update mode for gray scale images.
-            update_mode = self.DISPLAY_UPDATE_MODE_GC16
-        # Blit the image to the display
-        self.display_area(x, y, width, height, update_mode)
+                # Use a slower, flashy update mode for gray scale images.
+                update_mode = self.DISPLAY_UPDATE_MODE_GC16
+            # Blit the image to the display
+            if bbox:
+                (left, top, right, bottom) = bbox
+                self.display_area(left, top, right-left, bottom-top, update_mode)
+            else:
+                self.display_area(x, y, width, height, update_mode)
 
     def clear(self):
         image = Image.new('1', (self.width, self.height), self.white)

--- a/papertty/drivers/drivers_base.py
+++ b/papertty/drivers/drivers_base.py
@@ -50,6 +50,7 @@ class DisplayDriver(ABC):
         self.enable_1bpp = None
         self.align_1bpp_width = None
         self.align_1bpp_height = None
+        self.supports_multi_draw = None
 
     @abstractmethod
     def init(self, **kwargs):

--- a/papertty/drivers/drivers_full.py
+++ b/papertty/drivers/drivers_full.py
@@ -52,6 +52,7 @@ class WaveshareFull(WaveshareEPD):
         self.enable_1bpp = False
         self.align_1bpp_width = False
         self.align_1bpp_height = False
+        self.supports_multi_draw = False
 
     def wait_until_idle(self):
         while self.digital_read(self.BUSY_PIN) == 0:  # 0: busy, 1: idle

--- a/papertty/papertty.py
+++ b/papertty/papertty.py
@@ -65,6 +65,7 @@ class PaperTTY:
     encoding = None
     spacing = 0
     vcom = None
+    hspacing = 0
     cursor = None
     rows = None
     cols = None
@@ -78,8 +79,8 @@ class PaperTTY:
         self.driver = get_drivers()[driver]['class']()
         self.spacing = spacing
         self.fontsize = fontsize
+        self.partial = partial #must come before load_font is called
         self.font = self.load_font(font) if font else None
-        self.partial = partial
         self.white = self.driver.white
         self.black = self.driver.black
         self.encoding = encoding
@@ -100,10 +101,10 @@ class PaperTTY:
 
     def set_tty_size(self, tty, rows, cols):
         """Set a TTY (/dev/tty*) to a certain size. Must be a real TTY that support ioctls."""
-        self.rows = rows
-        self.cols = cols
+        self.rows = int(rows)
+        self.cols = int(cols)
         with open(tty, 'w') as tty:
-            size = struct.pack("HHHH", int(rows), int(cols), 0, 0)
+            size = struct.pack("HHHH", self.rows, self.cols, 0, 0)
             try:
                 fcntl.ioctl(tty.fileno(), termios.TIOCSWINSZ, size)
             except OSError:
@@ -220,6 +221,27 @@ class PaperTTY:
         if font:
             self.recalculate_font(font)
 
+            #TODO: only if monospaced
+
+            #If partial refresh is enabled, make sure that font_height and font_width are divisible by 4.
+            #This is to avoid two potentially problematic scenarios.
+            #The first is an image with an odd height being rotated, which can cause problems in the
+            #currently used version (7.1.2) of PIL.
+            #The second is an image with a dimension not visible by 4, which can cause problems with the
+            #IT8951 driver, likely due to that driver requiring 4bpp.
+            if self.is_truetype and self.partial:
+                offset = 4 - (self.font_width % 4)
+                if offset % 4 != 0:
+                    print("Setting horizontal spacing to: "+str(offset))
+                    self.hspacing = offset
+                    self.font_width += offset
+
+                offset = 4 - (self.font_height % 4)
+                if offset % 4 != 0:
+                    print("Increasing spacing from "+str(self.spacing)+" to "+str(self.spacing+offset))
+                    self.spacing += offset
+                    self.font_height += offset
+
         return font
 
     def recalculate_font(self, font):
@@ -249,7 +271,7 @@ class PaperTTY:
 
     def fit(self, portrait=False):
         """Return the maximum columns and rows we can display with this font"""
-        width = self.font.getsize('M')[0]
+        width = self.font_width
         height = self.font_height
         # hacky, subtract just a bit to avoid going over the border with small fonts
         pw = self.driver.width - 3
@@ -397,9 +419,19 @@ class PaperTTY:
                 previous_vnc_image = new_vnc_image.copy()
                 time.sleep(float(sleep))
 
-    def showtext(self, text, fill, cursor=None, portrait=False, flipx=False, flipy=False, oldimage=None):
+    def showtext(self, text, fill, cursor=None, portrait=False, flipx=False, flipy=False, oldimage=None, oldtext=None, oldcursor=None):
         """Draw a string on the screen"""
         if self.ready():
+            
+            #If partial updates are supported, run partialdraw_showtext() instead
+            #as it should be more efficient.
+            if self.driver.supports_partial and self.partial:
+                
+                if oldtext is None:
+                    oldtext = ""
+
+                return self.partialdraw_showtext(text=text, fill=fill, cursor=cursor, portrait=portrait, flipx=flipx, flipy=flipy, oldimage=oldimage, oldtext=oldtext, oldcursor=oldcursor)
+
             # set order of h, w according to orientation
             image = Image.new('1', (self.driver.width, self.driver.height) if portrait else (
                 self.driver.height, self.driver.width),
@@ -449,7 +481,554 @@ class PaperTTY:
             return image
         else:
             self.error("Display not ready")
+
+
+
+    def partialdraw_showtext(self, text, fill, cursor, portrait, flipx, flipy, oldimage, oldtext, oldcursor):
+
+        """Draw a string on the screen one line at a time.
+           This function serves as an alternative to showtext() and aims to be more efficient
+           by comparing string values instead of diffing images.
+           It is especially fast for any drivers with self.supports_multi_draw = True.
+           (supports_multi_draw is currently only supported by the IT8951 driver)
+        """
+
+        #First, grab oldtext (the text from the previous render) and text (the text from
+        #the current render), then split them up based on a newline delimiter.
+        #This is so we can compare the previous state of the text to the current state
+        #of the text line by line and only redraw the lines which have actually changed.
+        oldlines = oldtext.split('\n')
+        newlines = text.split('\n')
+
+
+        #Use the font height as the height for other measurements, such as row height
+        height = self.font_height
+
+        
+        #First, run through each row and build a list of strings to potentially draw
+        changedLines = self.partialdraw_get_changed_lines(cursor, oldcursor, oldlines, newlines)
+
+
+        #If this panel doesn't support multiple draws in a single refresh, then we
+        #are probably better off merging the individual lines of text into a single
+        #block and drawing that instead.
+        #This is because of the overhead involved with each individual write to the
+        #GPIO pins, so it can be faster to do one big write instead of two small writes.
+        #
+        #There's no strict rule of which is faster.
+        #It depends on the speed of the machine (eg. rpi zero vs rpi 4b) and the speed
+        #of the panel refresh.
+        #
+        #The value of maxRedraw should probably always be either 1 or 2.
+        if not self.driver.supports_multi_draw:
+            maxRedraw = 1
+            blocks = self.partialdraw_get_text_blocks(changedLines)
+            self.partialdraw_merge_text_blocks(blocks, maxRedraw, changedLines)
+        
+
+        #For each line in `changedLines`, figure out its coordinates and other information
+        #needed for drawing.
+        linesToDraw = self.partialdraw_get_lines_to_draw(changedLines, height, flipy, portrait)
+        
+
+        #Take those lines and turn them into actual images, performing all necessary
+        #rotation, coordinate adjustments, etc.
+        imagesToDraw = self.partialdraw_get_images_to_draw(linesToDraw, cursor, oldcursor, height, fill, portrait, flipx, flipy)
+
+
+        #If oldimage is defined, update it by drawing the new frames onto it.
+        #If not, create a new full-screen image.
+        #In either case, don't actually draw the fullscreen image.
+        #We're building it to a) return a full-screen image as the return value for
+        #compatibility with other papertty functions and b) perform cropping for
+        #1bpp alignment.
+        if not oldimage:
+            oldimage = Image.new('1', (self.driver.width, self.driver.height) if portrait else (self.driver.height, self.driver.width), self.white)
+        
+
+        #Array of bounded images to pass through to draw_multi if the driver
+        #supports it via driver.supports_multi_draw
+        imageArray = []
+
+
+        #For each image we want to draw, paste the image onto the fullscreen image (oldimage).
+        #Then build a bbox and band the image coordinates we required by the board
+        #and bpp setting.
+        #Finally, either draw the image immediately, or put it in imageArray so it can be
+        #drawn in bulk.
+        for arr in imagesToDraw:
+            oldimage.paste(arr[2], (arr[0], arr[1])) #for the return data
+
+            diff_bbox = ( \
+                arr[0], \
+                arr[1], \
+                arr[0] + arr[2].width, \
+                arr[1] + arr[2].height \
+            )
+            if self.driver.supports_1bpp and self.driver.enable_1bpp:
+                xdiv = self.driver.align_1bpp_width
+                ydiv = self.driver.align_1bpp_height
+            else:
+                xdiv = 8
+                ydiv = 1
+            bbox = self.band(diff_bbox, xdiv=xdiv, ydiv=ydiv)
+
+            if self.driver.supports_multi_draw:
+                imageArray.append([bbox[0], bbox[1], oldimage.crop(bbox)])
+            else:
+                self.driver.draw(bbox[0], bbox[1], oldimage.crop(bbox))
+
+
+        if self.driver.supports_multi_draw:
+            self.driver.draw_multi(imageArray)
+
+
+        return oldimage
     
+    def partialdraw_get_changed_lines(self, cursor, oldcursor, oldlines, newlines):
+
+        """This function compares two strings arrays, oldlines and newlines, and
+            figures out which lines of text in those arrays are different.
+            It also takes cursor position into consideration when figuring out if
+            the text has "changed" or not."""
+
+        #List of lines of text which have changed
+        changedLines = []
+
+        for i in range(self.rows):
+            
+            newval = newlines[i] if i < len(newlines) else ''
+            oldval = oldlines[i] if i < len(oldlines) else ''
+
+            #Use these variables to check if the cursor has moved
+            cursorIsOnThisLine = False
+            cursorWasOnThisLine = False
+            cursorMovedHorizontally = False
+
+            if cursor and self.cursor:
+                cur_y = cursor[1]
+                if cur_y == i:
+                    cursorIsOnThisLine = True
+
+            if oldcursor:
+                cur_y = oldcursor[1]
+                if cur_y == i:
+                    cursorWasOnThisLine = True
+
+            #If the cursor was on this line last render, and it's still on this line
+            #this render, then we need to check the x axis (cursor[0]) and the text
+            #to judge whether the cursor needs drawing or not.
+            #If it doesn't need drawing, set both variables to false.
+            if cursorIsOnThisLine and cursorWasOnThisLine:
+                if oldcursor[0] != cursor[0]:
+                    cursorMovedHorizontally = True
+                elif oldval == newval:
+                    cursorIsOnThisLine = False
+                    cursorWasOnThisLine = False
+
+            #Draw this line if either the cursor has moved, or the text has changed
+            drawThisLine = cursorMovedHorizontally or cursorIsOnThisLine != cursorWasOnThisLine or oldval != newval
+
+            lineToDraw = [drawThisLine, newval, cursorIsOnThisLine, oldval, cursorWasOnThisLine]
+            changedLines.append(lineToDraw)
+
+        return changedLines
+
+    def partialdraw_get_text_blocks(self, changedLines):
+
+        """This function takes the result of partialdraw_get_changed_lines and
+            groups consecutive lines together in order to create blocks of text."""
+
+        #Array of grouped text blocks
+        blocks = []
+
+        #Used in the loop to keep track of whether the previous line was flagged for
+        #drawing or not
+        drawLastLine = False
+        
+        for i, arr in enumerate(changedLines):
+            
+            drawThisLine = arr[0]
+
+            #If this line is to be drawn, and so was the previous line, group them
+            #together in the same block.
+            #If this line is to be drawn, but the previous one wasn't, then start a
+            #new block instead.
+            if drawThisLine:
+                if drawLastLine:
+                    blocks[-1][1] = i
+                else:
+                    blocks.append([i, i])
+
+            drawLastLine = drawThisLine
+
+        return blocks
+
+    def partialdraw_merge_text_blocks(self, blocks, maxRedraw, changedLines):
+
+        """This function takes the result of partialdraw_get_text_blocks
+            and merges the text blocks together until the total number of block
+            does not exceed `maxRedraw`."""
+
+        #If the number of blocks to draw is more than we want to redraw separately
+        #(`maxRedraw`), then batch them together.
+        #We do this by setting `drawThisLine` (the first parameter of changedLines)
+        #to True for the lines in between separate blocks.
+        #This causes the "block" to be made bigger artificially by drawing lines we
+        #don't need to, which in turn leverages the "append" behavior in the drawing loop.
+        #
+        #This sounds counter-productive, but it actually speeds things up in cases where
+        #we can't perform multiple independent writes to the board in a single refresh.
+        #This is because each individual write to SPI incurs overhead, and each individual
+        #write also triggers a redraw by the e-ink panel which has its own delay.
+        #So if we're looking to do multiple small writes, sometimes it's preferable to do one
+        #bigger write instead.
+
+        if len(blocks) > maxRedraw:
+
+            #First, iterate through each block and figure out how big the gap is between
+            #that block and the next block.
+            #Then when we've found the smallest gap, merge those two blocks together.
+            #Repeat this process until the number of blocks does not exceed `maxRedraw`.
+            #The smallest gap is used as the criteria for merging because a "gap" between
+            #blocks is a section of lines which otherwise don't need to be drawn.
+            #Any of those lines we do draw is extra overhead.
+            #So to minimize that extra overhead, we make a point of looking for the
+            #smallest gaps.
+
+            while len(blocks) > maxRedraw:
+                smallestGap = -1
+                smallestGapIndex = -1
+                for i in range(len(blocks) - 1):
+                    thisBlock = blocks[i]
+                    nextBlock = blocks[i+1]
+                    thisBlockEnd = thisBlock[1]
+                    nextBlockStart = nextBlock[0]
+                    gap = nextBlockStart - thisBlockEnd
+                    if smallestGap == -1 or gap < smallestGap:
+                        smallestGap = gap
+                        smallestGapIndex = i
+                blockToMerge = blocks.pop(smallestGapIndex+1)
+                blocks[smallestGapIndex][1] = blockToMerge[1]
+
+            #Next, iterate through all of the lines of text we were going to draw
+            #(or not draw) and reassess whether to draw them or not based on whether
+            #they're in one of the calculated text blocks.
+            #Setting changedLines[i][0] to True means that line of text will be
+            #flagged for merging in the drawing loop elsewhere in the code.
+
+            for i, arr in enumerate(changedLines):
+                for block in blocks:
+                    if i >= block[0] and i <= block[1]:
+                        changedLines[i][0] = True
+                        break
+
+    def partialdraw_get_lines_to_draw(self, changedLines, height, flipy, portrait):
+
+        """This function takes the result of partialdraw_get_changed_lines and
+            figures out where and how to draw the line.
+            This includes flagging the line of text as one which should be merged,
+            figuring out which characters in the text line have actually changed,
+            and other information useful for the text drawing loop."""
+        
+        #`append` is a flag to indicate that the current line should be merged with the
+        #preceding line instead of being drawn separately.
+        #This is part of a performance optimization; it's less expensive to draw a double-line
+        #height image than it is to draw two single-line height images.
+        append = False
+
+        linesToDraw = []
+
+        for i, arr in enumerate(changedLines):
+            drawThisLine = arr[0]
+            newval = arr[1]
+            cursorIsOnThisLine = arr[2]
+            oldval = arr[3]
+            cursorWasOnThisLine = arr[4]
+
+            #Calculate the y coordinate based on the row number and font height.
+            #If flipy is set, count the rows backwards, since we want to draw from
+            #the "end" (which flipy moves to the start of the screen) instead.
+            if flipy:
+
+                #Calculate the gap between the last row and the edge of the screen,
+                #then add it to y.
+                #This is because we want the gap between the "last" row (which,
+                #when flipped, becomes the first row) to be at the bottom of the screen,
+                #not the top.
+                offset_y = (self.driver.height if portrait else self.driver.width) % self.font_height
+                
+                #We want to count backwards from 1 row BEFORE self.rows, since that's
+                #the maximum index we would actually draw at when counting forwards.
+                maxRowIndex = self.rows - 1
+
+                y = (maxRowIndex - i) * height
+                y += offset_y
+            else:
+                y = i * height
+
+            if not drawThisLine:
+
+                #If the cursor hasn't moved to/from this line and the text hasn't changed,
+                #then don't add this line to the `linesToDraw` array.
+                #Just set append to false, since we aren't drawing this line and thus can't
+                #append to it
+                append = False
+
+            else:
+                firstChanged = -1
+                lastChanged = 0
+                oldlen = len(oldval)
+                newlen = len(newval)
+                smallerLen = min(oldlen, newlen)
+
+                #Iterate through the old text value and the new text value char by char
+                #in order to find the first non-matching character.
+                #Or, if either string is empty, set firstChanged to 0.
+                if oldlen == 0 or newlen == 0:
+                    firstChanged = 0
+                else:
+                    for j in range(smallerLen):
+                        oldChar = oldval[j]
+                        newChar = newval[j]
+                        if oldChar != newChar:
+                            firstChanged = j
+                            break
+
+                #firstChanged might not be set if one line completely encapsulates the other.
+                #eg. if the line changed from "test" to "testing" then they are identical
+                #until the last char of the old string, so firstChanged would never be set.
+                #In that case, set firstChanged to be the final character of whichever line
+                #is shorter.
+                if firstChanged == -1:
+                    firstChanged = min(oldlen, newlen) - 1
+
+                #Next, try to find the LAST non-matching character.
+                #If the line length has changed, then the last char won't match, so just
+                #set it to that. Otherwise, iterate char by char again.
+                if newlen != oldlen:
+                    lastChanged = max(oldlen, newlen) - 1
+                else:
+                    for j in range(newlen):
+                        oldChar = oldval[j]
+                        newChar = newval[j]
+                        if oldChar != newChar:
+                            lastChanged = j
+
+                #Set the x coordinate to start at `firstChanged` since we won't draw
+                #anything before that.
+                x = firstChanged * self.font_width
+
+                #`subsequentLines` is a list of lines which come after the current line,
+                #but should be drawn in the same image as this line.
+                #This is so we can draw consecutive altered lines into a single image and
+                #minimize the number of SPI writes.
+                subsequentLines = []
+
+                lineToDraw = [x, y, newval, cursorIsOnThisLine, subsequentLines, firstChanged, lastChanged, cursorWasOnThisLine]
+
+                #If append is true, that means this line and the previous line were both altered.
+                #So we're going to take the current line and append it to the previous line and
+                #draw them together.
+                if append:
+
+                    lastIndex = len(linesToDraw) - 1
+                    linesToDraw[lastIndex][4].append(lineToDraw)
+
+                else:
+
+                    linesToDraw.append(lineToDraw)
+                    append = True
+
+        return linesToDraw
+
+    def partialdraw_get_images_to_draw(self, linesToDraw, cursor, oldcursor, height, fill, portrait, flipx, flipy):
+
+        """This function takes the result of partialdraw_get_lines_to_draw and turns
+            each line into an image. It takes care of rotation, adjusting the
+            coordinates, and so on."""
+
+        #List of images (lines of text) to draw
+        imagesToDraw = []
+        
+        for i, arr in enumerate(linesToDraw):
+
+            #Grab the current line and subsequent lines, then put them all in a list together
+            chunks = [[arr[0], arr[1], arr[2], arr[3], arr[5], arr[6], arr[7]]]
+            for line in arr[4]:
+                chunks.append([line[0], line[1], line[2], line[3], line[5], line[6], line[7]])
+
+            #Run the chunks of text through the partialdraw_get_indexes_from_chunks function.
+            #This will tell us the first and last character indexes to draw.
+            #TODO: if the font isn't monospace, this should just cover the entire line
+            (smallestStartIndex, biggestEndIndex) = self.partialdraw_get_indexes_from_chunks(chunks, cursor, oldcursor)
+
+            #Calculate the starting x coordinate (smallest_x) and the ending x coordinate
+            #(biggest_x) of the block.
+            smallest_x = smallestStartIndex * self.font_width
+            biggest_x = biggestEndIndex * self.font_width
+
+            #For each text chunk, reduce its length based on the chars we want to draw.
+            for chunk in chunks:
+                chunk[2] = chunk[2][smallestStartIndex:biggestEndIndex+1]
+
+            #Calculate the image width based on how many chars have changed.
+            #eg. If the text changed from "test" to "testing", then 3 chars have changed.
+            #So the image width will be 3 x font_width.
+            diffIndex = biggestEndIndex - smallestStartIndex
+            diffRows = diffIndex + 1
+            rowWidth = diffRows * self.font_width
+
+            #Line height doesn't change based on orientation, since image.rotate will
+            #resize as needed.
+            lineHeight = height
+
+            #Calculate the row height by multiplying the line height by the number of chunks
+            rowHeight = lineHeight * len(chunks)
+
+            #Draw the image
+            image = self.partialdraw_build_image(rowWidth, rowHeight, chunks, height, fill, cursor, smallestStartIndex)
+
+            #Rotate and/or flip image, if needed
+            if not portrait:
+                image = image.rotate(90, expand=True)
+            if flipx:
+                image = image.transpose(Image.FLIP_LEFT_RIGHT)
+            if flipy:
+                image = image.transpose(Image.FLIP_TOP_BOTTOM)
+            
+            #Figure out where to draw the image based on either the first or last
+            #chunk's coordinates
+            if flipy:
+                chunk = chunks[-1]
+            else:
+                chunk = chunks[0]
+
+            #Add this image to the list of images to draw
+            offset_x = 0 #self.driver.width % self.font_width
+            if portrait:
+                y = chunk[1]
+                if flipx:
+                    x = self.driver.width - image.width + offset_x - smallest_x
+                else:
+                    x = smallest_x
+            else:
+                if flipx:
+                    y = self.driver.height - image.height + offset_x - smallest_x
+                    x = self.driver.width - chunk[1] - image.width
+                else:
+                    x = chunk[1]
+                    y = self.driver.height - image.height - smallest_x
+
+            imagesToDraw.append([x, y, image])
+
+        return imagesToDraw
+
+    def partialdraw_get_indexes_from_chunks(self, chunks, cursor, oldcursor):
+
+        """Calculates the starting and ending character indexes of a text block.
+            eg. If chunk[0] only chanes from characters 0-4, but chunk[1] changed
+            from characters 3-6, then we would want to know the first changed
+            character (0) and last changed character (6)."""
+        
+        smallestStartIndex = -1
+        biggestEndIndex = 0
+
+        for chunk in chunks:
+            startIndex = chunk[4]
+            endIndex = chunk[5]
+
+            #Don't bother checking lines where nothing has changed.
+            #This could be because the line is part of a block update.
+            #So it hasn't changed, but needs to be redrawn anyway.
+            if startIndex == endIndex:
+                pass
+            if startIndex < smallestStartIndex or smallestStartIndex == -1:
+                smallestStartIndex = startIndex
+            if endIndex > biggestEndIndex:
+                biggestEndIndex = endIndex
+
+        #If the cursor has moved, make sure it is drawn
+        for chunk in chunks:
+            cursorIsOnThisLine = chunk[3]
+            cursorWasOnThisLine = chunk[6]
+
+            #If the cursor both was and still is on this line, it may have moved horizontally.
+            #Check if x coordinates match.
+            #If they don't match, then the cursor has moved and needs to be redrawn.
+            #In which case we should adjust the smallest/biggest index of the text
+            #redraw to include the cursor.
+            if cursorIsOnThisLine and cursorWasOnThisLine:
+                cur_x = cursor[0]
+                old_x = oldcursor[0]
+                if cur_x != old_x:
+                    smaller_x = min(cur_x, old_x)
+                    bigger_x = max(cur_x, old_x)
+                    if smallestStartIndex == -1 or smaller_x < smallestStartIndex:
+                        smallestStartIndex = smaller_x
+                    if bigger_x > biggestEndIndex:
+                        biggestEndIndex = bigger_x
+
+            #If the cursor is now on a different line than it was before, and it is/was on this
+            #particular line, then we need to make sure the draw includes the index where the
+            #cursor is/was.
+            if cursorIsOnThisLine != cursorWasOnThisLine:
+                if cursorIsOnThisLine:
+                    cur_x = cursor[0]
+                else:
+                    cur_x = oldcursor[0]
+                if smallestStartIndex == -1 or cur_x < smallestStartIndex:
+                    smallestStartIndex = cur_x
+                if cur_x > biggestEndIndex:
+                    biggestEndIndex = cur_x
+
+        return (smallestStartIndex, biggestEndIndex)
+
+    def partialdraw_build_image(self, rowWidth, rowHeight, chunks, height, fill, cursor, smallestStartIndex):
+
+        """Builds an image based on the chunks of text and size parameters passed in.
+            Also draws the cursor, if needed."""
+
+
+        #First, create an image with the expected dimensions.
+        image = Image.new('1', (rowWidth, rowHeight), self.white)
+
+
+        #Then get the ImageDraw object so we can actually draw on the image.
+        draw = ImageDraw.Draw(image)
+
+
+        #For each chunk, draw the text and possibly the cursor
+        for j, chunk in enumerate(chunks):
+            x = 0
+            y = j * height
+            newval = chunk[2]
+            cursorIsOnThisLine = chunk[3]
+
+            #If hspacing is zero, just draw the whole line of text in one go.
+            #If not, draw the characters one at a time, with that much spacing in between.
+            if self.hspacing == 0:
+                draw.text((x, y), newval, font=self.font, fill=fill, spacing=self.spacing)
+            else:
+                for character in newval:
+                    draw.text((x, y), character, font=self.font, fill=fill, spacing=self.spacing)
+                    x += self.font_width
+
+            #Draw the cursor, if it's on this line
+            if cursorIsOnThisLine:
+
+                #Adjust cursor's coordinate so they're relative to the text chunk's position
+                cursor_x = cursor[0] - smallestStartIndex
+                cursor_y = j
+                
+                newcursor = (cursor_x, cursor_y, cursor[2])
+                if self.cursor == 'block':
+                    image = self.draw_block_cursor(newcursor, image)
+                else:
+                    self.draw_line_cursor(newcursor, draw)
+
+        return image
+
     def clear(self):
         """Clears the display; set all black, then all white, or use INIT mode, if driver supports it."""
         if self.ready():
@@ -885,6 +1464,8 @@ def terminal(settings, vcsa, font, fontsize, noclear, nocursor, cursor, sleep, t
                         # show new content
                         oldimage = ptty.showtext(buff, fill=ptty.black, cursor=cursor if not nocursor else None,
                                                 oldimage=oldimage,
+                                                oldtext=oldbuff,
+                                                oldcursor=oldcursor,
                                                 **textargs)
                         oldbuff = buff
                         oldcursor = cursor


### PR DESCRIPTION
Alright, here's the big one. This PR introduces a complete rewrite of the partial redraw functionality of terminal mode.
It also implements a new drawing mode for the drivers. It's only in IT8951 for now, but in theory other panels might support it.

TL;DR: the overhead of papertty's logic has been reduced by 90+% in many common scenarios, such as while typing a command, and even more so in other scenarios involving multiple screen elements being modified

### Image diffing

The main bottleneck being addressed by this PR is the use of image diffing.
Terminal mode currently performs partial draws by using img_diff to compare two images.
So what happens is that a full-screen image is built, img_diff is used to compare it to the previous frame, and the calculated difference between them is drawn to the panel.

This works, but the performance overhead is quite large.
This becomes especially noticeable when using a high-res panel and a low-spec raspberry pi.
It's still measurable (but not as noticeable) with higher-spec raspberry pis as well.

For the majority of my testing I've been using a waveshare 10.3" HD panel with a resolution of 1872 x 1404.
Performing img_diff on a rpi 4b takes around 200-250ms.
Performing img_diff on a rpi 2b takes around 800-1200ms.
So it is far more noticeable on the 2b, but it's still a fair delay on the 4b.

The big change in this PR is to replace that image diffing with text diffing.
Comparing 50 lines of text is significantly faster than comparing 2.6 million pixels of image data.

The testing and progress of this was somewhat covered here https://github.com/joukos/PaperTTY/issues/107
For the rpi 2b, the change from image diffing to text diffing resulted in a drop of latency from 800->200ms.
For the 4b, the change dropped latency from 200-250ms -> 8-12ms.

*Note that these numbers are only for the papertty logic and I think the SPI writes.
They do not include panel refresh time.
Also note that these numbers are for small differences on the screen, such as typing.
They do not represent large screen changes, such as scrolling.

### Multi writes

The second change this PR introduces is currently specific to the IT8951 panel.
It's not directly related to the above changes in papertty.py, but it does require changes to papertty.py in order to take advantage of it, hence I've included it in this PR.

This change is to add support for multiple draws in a single panel refresh.
This cuts down on driver overhead by allowing for multiple small images to be drawn in one go instead of a single big image.

For example, consider a writing application such as wordgrinder.
The text is typed in the middle of the screen.
Separately, there's a word count down the bottom right of the screen.
Each one only receives minor changes, but they are on different parts of the screen.

The old way of handling this would be to draw them both and the space in between.
With text in the middle of the screen and the word count down the bottom of the screen, this would mean effectively drawing half of the screen. (over 1 million pixels on my panel)
With 1bpp mode enabled, that's still 1 million bits, or 122KB, to write over SPI.

Writing the two images separately (the old way) would mean much smaller images.
For example, if you're using a size 30 font, and you type a 5-letter word, then you would have 2 images: a 160x32 image for the text change, and a 32x32 image for the word count.
That's 6,144 bits, or 768 bytes. Obviously a very significant reduction.

The problem then is that each panel refresh has its own overhead.
With A2 mode, the panel refresh is 120ms.
So doing 2 writes would save on the bits written, but add latency by doing 2 refreshes.

With this PR, those two writes would be performed in a single panel refresh.
This is because with IT8951 (and possibly other panels) it's possible to set the coordinates on the screen, write data, change the coordinates, write data, THEN do a refresh.
So you can write multiple images, but still only perform a single refresh.

(This is not specific to IT8951, and it's not specific to the terminal mode changes. However, the terminal mode changes have been written to support this new mode, and I only have an IT8951 panel for testing, so...)

### Summary

All up, this should result in significant latency reduction, depending on the use case.
Things like full-screen refreshes or scrolling are still slow, of course.
But common operations like simply typing are significantly faster.

Currently the changes are on by default, but let me know if you think a flag should be added to enable/disable this functionality.

I've tested this on all orientations, with all variations of portrait, flipx and flipy.
I've also tested with multi_draw on and off.
All testing has been done on the same panel, however, due to lacking hardware.