### PR TITLE
Gpiozero - rpi5 support?

### DIFF
--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -4,10 +4,10 @@ import struct
 import time
 
 from papertty.drivers.drivers_base import DisplayDriver
+from papertty.drivers.drivers_base import GPIO
 
 try:
     import spidev
-    import RPi.GPIO as GPIO
 except ImportError:
     pass
 except RuntimeError as e:

--- a/papertty/drivers/drivers_4in2.py
+++ b/papertty/drivers/drivers_4in2.py
@@ -17,15 +17,9 @@
 
 from PIL import Image
 
+from papertty.drivers.drivers_base import GPIO
 from papertty.drivers.drivers_consts import EPD4in2const
 from papertty.drivers.drivers_partial import WavesharePartial
-
-try:
-    import RPi.GPIO as GPIO
-except ImportError:
-    pass
-except RuntimeError as e:
-    print(str(e))
 
 # The driver works as follows:
 #

--- a/papertty/drivers/drivers_base.py
+++ b/papertty/drivers/drivers_base.py
@@ -32,8 +32,9 @@ except RuntimeError as e:
 # Optional dependency
 try:
     from gpiozero import OutputDevice, InputDevice
+    print("gpiozero found - using that instead of RPi.GPIO")
 except ImportError:
-    print("gpiozero not found")
+    print("gpiozero not found - defaulting to RPi.GPIO")
     pass
 
 class GPIO:
@@ -62,8 +63,6 @@ class GPIO:
             else:
                 GPIO.pins[str(pin)] = InputDevice(pin)
         except Exception as e:
-            print(e)
-            print("gpiozero not supported")
             GPIO.pins[str(pin)] = False
             rpiGPIO.setup(pin, ioType)
 

--- a/papertty/drivers/drivers_base.py
+++ b/papertty/drivers/drivers_base.py
@@ -23,12 +23,65 @@ import time
 # using them
 try:
     import spidev
-    import RPi.GPIO as GPIO
+    import RPi.GPIO as rpiGPIO
 except ImportError:
     pass
 except RuntimeError as e:
     print(str(e))
 
+# Optional dependency
+try:
+    from gpiozero import OutputDevice, InputDevice
+except ImportError:
+    print("gpiozero not found")
+    pass
+
+class GPIO:
+
+    OUT = rpiGPIO.OUT
+    IN = rpiGPIO.IN
+    BCM = rpiGPIO.BCM
+    LOW = rpiGPIO.LOW
+    HIGH = rpiGPIO.HIGH
+
+    pins = {}
+
+    @staticmethod
+    def setmode(value):
+        rpiGPIO.setmode(value)
+
+    @staticmethod
+    def setwarnings(value):
+        rpiGPIO.setwarnings(value)
+
+    @staticmethod
+    def setup(pin, ioType):
+        try:
+            if ioType == GPIO.OUT:
+                GPIO.pins[str(pin)] = OutputDevice(pin)
+            else:
+                GPIO.pins[str(pin)] = InputDevice(pin)
+        except Exception as e:
+            print(e)
+            print("gpiozero not supported")
+            GPIO.pins[str(pin)] = False
+            rpiGPIO.setup(pin, ioType)
+
+    @staticmethod
+    def input(pinNo):
+        pin = GPIO.pins[str(pinNo)]
+        if pin == False:
+            return rpiGPIO.input(pinNo)
+        else:
+            return pin.value
+
+    @staticmethod
+    def output(pinNo, value):
+        pin = GPIO.pins[str(pinNo)]
+        if pin == False:
+            rpiGPIO.output(pinNo, value)
+        else:
+            pin.on() if value == 1 else pin.off()
 
 class DisplayDriver(ABC):
     """Abstract base class for a display driver - be it Waveshare e-Paper, PaPiRus, OLED..."""


### PR DESCRIPTION
This PR creates an optional dependency on gpiozero as an alternative to RPi.GPIO.
This is because RPi.GPIO hasn't been updated in almost 2 years and does not support the new memory mapping of the GPIO pins on the raspberry pi 5, whereas gpiozero does support the rpi5.

It has been added as an optional dependency, and it's been implemented as a shim of sorts so that most of the code can remain unchanged.
If gpiozero is detected, it will be used. Otherwise it will default to rpi.gpio.

I've found no notable speed difference between the two.
I've tested with it installed and uninstalled, both on a IT8951 panel and on a EPD3in7 panel, with a rpi3a and a rpi zero, and everything appears to be working correctly.

I have NOT tested with an rpi5 to confirm if this does indeed add rpi5 support to papertty, as I do not own a rpi5 currently.

If papertty has been installed via pip, then gpiozero can be installed by going into the venv and installing it.
eg.
```
source papertty_venv/bin/activate
pip3 install gpiozero
```
When starting papertty it will tell you if it's running gpiozero or not.