### PR TITLE
Improved Epd3in7 support

### DIFF
--- a/papertty/drivers/drivers_base.py
+++ b/papertty/drivers/drivers_base.py
@@ -222,6 +222,12 @@ class WaveshareEPD(DisplayDriver):
         # so use [data] instead of data
         self.spi_transfer([data])
 
+    def send_data_multi(self, dataArray):
+        self.digital_write(self.DC_PIN, GPIO.HIGH)
+        max_transfer_size = 4096
+        for i in range(0, len(dataArray), max_transfer_size):
+            self.spi_transfer(dataArray[i: i + max_transfer_size])
+
     def reset(self):
         self.digital_write(self.RST_PIN, GPIO.LOW)
         self.delay_ms(200)

--- a/papertty/drivers/drivers_full.py
+++ b/papertty/drivers/drivers_full.py
@@ -430,12 +430,16 @@ class EPD3in7(WaveshareFull):
             self.send_data(0x00)
 
             self.send_command(0x24)
-            for j in range(0, self.height):
-                for i in range(0, int(self.width / 8)):
-                    self.send_data(frame_buffer[i + j * int(self.width / 8)])   
+            self.send_data_multi(frame_buffer)
 
             self.send_command(0x20)
-            self.wait_until_idle()   
+            self.wait_until_idle()
+
+    def draw(self, x, y, image):
+        """Display an image - this module does not support partial refresh: x, y are ignored"""
+        frame_buffer = self.pack_image(image)
+        self.display_frame(frame_buffer, x, y)
+
     def pack_image(self, image):
         """Packs a PIL image for transfer over SPI to the driver board."""
 

--- a/papertty/drivers/drivers_full.py
+++ b/papertty/drivers/drivers_full.py
@@ -417,8 +417,7 @@ class EPD3in7(WaveshareFull):
 
     def load_lut(self, lut):
         self.send_command(0x32)
-        for i in range(0, 105):
-            self.send_data(lut[i])
+        self.send_data_multi(lut)
 
     def display_frame(self, frame_buffer, *args):
         if frame_buffer:

--- a/papertty/drivers/drivers_full.py
+++ b/papertty/drivers/drivers_full.py
@@ -355,17 +355,13 @@ class EPD3in7(WaveshareFull):
         self.wait_until_idle()
         
         self.send_command(0x01) # setting gaet number
-        self.send_data(0xDF)
-        self.send_data(0x01)
-        self.send_data(0x00)
+        self.send_data_multi([0xDF,0x01,0x00])
 
         self.send_command(0x03) # set gate voltage
         self.send_data(0x00)
 
         self.send_command(0x04) # set source voltage
-        self.send_data(0x41)
-        self.send_data(0xA8)
-        self.send_data(0x32)
+        self.send_data_multi([0x41,0xA8,0x32])
 
         self.send_command(0x11) # set data entry sequence
         self.send_data(0x03)
@@ -374,11 +370,7 @@ class EPD3in7(WaveshareFull):
         self.send_data(0x00)
         
         self.send_command(0x0C) # set booster strength
-        self.send_data(0xAE)
-        self.send_data(0xC7)
-        self.send_data(0xC3)
-        self.send_data(0xC0)
-        self.send_data(0xC0)
+        self.send_data_multi([0xAE,0xC7,0xC3,0xC0,0xC0])
 
         self.send_command(0x18) # set internal sensor on
         self.send_data(0x80)
@@ -387,28 +379,15 @@ class EPD3in7(WaveshareFull):
         self.send_data(0x44)
         
         self.send_command(0x37) # set display option, these setting turn on previous function
-        self.send_data(0x00)     #can switch 1 gray or 4 gray
-        self.send_data(0xFF)
-        self.send_data(0xFF)
-        self.send_data(0xFF)
-        self.send_data(0xFF)  
-        self.send_data(0x4F)
-        self.send_data(0xFF)
-        self.send_data(0xFF)
-        self.send_data(0xFF)
-        self.send_data(0xFF)
+        #can switch 1 gray or 4 gray
+        #4gray not currently implemented
+        self.send_data_multi([0x00,0xFF,0xFF,0xFF,0xFF,0x4F,0xFF,0xFF,0xFF,0xFF])
 
         self.send_command(0x44) # setting X direction start/end position of RAM
-        self.send_data(0x00)
-        self.send_data(0x00)
-        self.send_data(0x17)
-        self.send_data(0x01)
+        self.send_data_multi([0x00,0x00,0x17,0x01])
 
         self.send_command(0x45) # setting Y direction start/end position of RAM
-        self.send_data(0x00)
-        self.send_data(0x00)
-        self.send_data(0xDF)
-        self.send_data(0x01)
+        self.send_data_multi([0x00,0x00,0xDF,0x01])
 
         self.send_command(0x22) # Display Update Control 2
         self.send_data(0xCF)
@@ -422,11 +401,9 @@ class EPD3in7(WaveshareFull):
     def display_frame(self, frame_buffer, *args):
         if frame_buffer:
             self.send_command(0x4E)
-            self.send_data(0x00)
-            self.send_data(0x00)
+            self.send_data_multi([0x00,0x00])
             self.send_command(0x4F)
-            self.send_data(0x00)
-            self.send_data(0x00)
+            self.send_data_multi([0x00,0x00])
 
             self.send_command(0x24)
             self.send_data_multi(frame_buffer)


### PR DESCRIPTION
This PR updates the EPD3in7 driver in the following ways:

- Adds 1bpp byte packing
- Implements a faster data sending method which sends 4k chunks instead of 1 byte at a time
- Adds partial screen update support (but does not turn it on - see comment on the function)

I've been testing this panel with a rpi zero, and the above (particularly the second change) makes it much faster.

Partial refresh would make it a lot faster still, but I suspect the partial refresh of this panel doesn't actually work (more on that in the code comments).