### PR TITLE
SPI speed arg in Mhz for IT8951 panel

### DIFF
--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -197,9 +197,10 @@ class IT8951(DisplayDriver):
 
         mhz = kwargs.get('mhz', None)
         if mhz:
-            self.SPI.max_speed_hz = mhz * 1000000
+            self.SPI.max_speed_hz = int(mhz * 1000000)
         else:
             self.SPI.max_speed_hz = 2000000
+        print("SPI Speed = %.02f Mhz" % (self.SPI.max_speed_hz / 1000.0 / 1000.0))
         
         self.SPI.mode = 0b00
 

--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -187,17 +187,20 @@ class IT8951(DisplayDriver):
             result = result[0:null_index]
         return result
 
-    def init(self, mhz=None, **kwargs):
+    def init(self, **kwargs):
         GPIO.setmode(GPIO.BCM)
         GPIO.setwarnings(False)
         GPIO.setup(self.RST_PIN, GPIO.OUT)
         GPIO.setup(self.CS_PIN, GPIO.OUT)
         GPIO.setup(self.BUSY_PIN, GPIO.IN)
         self.SPI = spidev.SpiDev(0, 0)
+
+        mhz = kwargs.get('mhz', None)
         if mhz:
             self.SPI.max_speed_hz = mhz * 1000000
         else:
             self.SPI.max_speed_hz = 2000000
+        
         self.SPI.mode = 0b00
 
         # It is unclear why this is necessary but it appears to be. The sample

--- a/papertty/drivers/driver_it8951.py
+++ b/papertty/drivers/driver_it8951.py
@@ -187,14 +187,17 @@ class IT8951(DisplayDriver):
             result = result[0:null_index]
         return result
 
-    def init(self, **kwargs):
+    def init(self, mhz=None, **kwargs):
         GPIO.setmode(GPIO.BCM)
         GPIO.setwarnings(False)
         GPIO.setup(self.RST_PIN, GPIO.OUT)
         GPIO.setup(self.CS_PIN, GPIO.OUT)
         GPIO.setup(self.BUSY_PIN, GPIO.IN)
         self.SPI = spidev.SpiDev(0, 0)
-        self.SPI.max_speed_hz = 2000000
+        if mhz:
+            self.SPI.max_speed_hz = mhz * 1000000
+        else:
+            self.SPI.max_speed_hz = 2000000
         self.SPI.mode = 0b00
 
         # It is unclear why this is necessary but it appears to be. The sample


### PR DESCRIPTION
This PR adds an optional --mhz argument for terminal mode.
It has only been implemented in terminal mode and for the IT8951 panel.

The implementation follows the same process as the optional VCOM argument.

If undefined, it will default to 2Mhz, which was already the hard-coded speed.

Adjusting the SPI speed may result in faster data transmission, depending on the driver board and rpi.
The waveshare docs suggest either 12.5MHz or 25MHz depending on which rpi it is.
This PR doesn't go as far as actually using those values or suggesting them.
But it does give users the option to set it themselves via a CLI argument. (Going through the issues here, some people have already been manually editing the value to try and get faster speeds)