### PR TITLE
Dependencies update

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ PaperTTY is currently packaged using Poetry, however it can be installed via pip
 
 **Then, you also need some system dependencies:**
 
-- `sudo apt install python3-venv python3-pip libopenjp2-7 libtiff5 libjpeg-dev`
+- `sudo apt install python3-venv python3-pip libopenjp2-7 libtiff5-dev libjpeg-dev libfreetype-dev`
 
 ### Install with pip to virtualenv
 


### PR DESCRIPTION
New builds of Raspberry Pi OS based on Debian 12 now require slightly different packages to work with PaperTTY.

libfreetype-dev is required before the installation of pillow, otherwise it will throw errors when you try to use PIL.

libtiff5-dev is required instead of libtiff5 since the latter isn't in the repos anymore.
Installing the -dev version automatically installs the appropriate version of the base libtiff package, so this works for both Debian 11 and 12-based versions of Raspberry Pi OS.