### PR TITLE
Fixes WavesharePartial panels not initializing

### DIFF
--- a/papertty/drivers/drivers_partial.py
+++ b/papertty/drivers/drivers_partial.py
@@ -63,7 +63,7 @@ class WavesharePartial(WaveshareEPD):
         self.colors = 2
         self.lut = None
 
-    def init(self, partial=True):
+    def init(self, partial=True, **kwargs):
         self.partial_refresh = partial
         if self.epd_init() != 0:
             return -1


### PR DESCRIPTION
It seems I can create branches on the official repo directly, but I can't merge them.

Anyway, this is a tiny change to make the WavesharePartial screens accept the new init arguments. It doesn't do anything with them, it's just a quick fix to make it not crash.